### PR TITLE
Performance improvements

### DIFF
--- a/Colored_De_Bruijn_graph_snippet.cpp
+++ b/Colored_De_Bruijn_graph_snippet.cpp
@@ -114,7 +114,7 @@ int main(int argc, char ** argv){
 		uint64_t color_number(file_names.size());
 
 		// I ALLOCATE THE COLOR VECTOR
-		vector<bool> color_me_amaze((ksl.number_kmer)*color_number,false);
+		vector<bool> color_me_amaze(ksl.number_kmer*color_number,false);
 		//NOT VERY SMART I KNOW...
 
 		// FOR EACH LINE OF EACH INDEXED FILE
@@ -124,26 +124,15 @@ int main(int argc, char ** argv){
 			vector<int64_t> kmer_ids;
 			while(not in.eof()){
 				getline(in,line);
-				if(line[0]!= 'A' and line[0]!= 'C' and line[0]!= 'G' and line[0]!= 'T' ){
-					continue;
-				}
-				//~ cout<<line<<endl;
 				// I GOT THE IDENTIFIER OF EACH KMER
 				kmer_ids=ksl.query_sequence_hash(line);
-				//~ cout<<"HASH"<<endl;
 				for(uint64_t i(0);i<kmer_ids.size();++i){
 					//I COLOR THEM
-					if(kmer_ids[i]>=0){
-						//~ cout<<kmer_ids[i]*color_number+i_file<<"\n"<<endl;
-						color_me_amaze[kmer_ids[i]*color_number+i_file]=true;
-						//~ cout<<color_me_amaze.size()<<"cgood"<<endl;;
-					}
+					color_me_amaze[kmer_ids[i]*color_number+i_file]=true;
 				}
 			}
 		}
 
-
-		cout<<"GO QUERY"<<endl;
 		ifstream query_file(query);
 
 		string line;
@@ -151,9 +140,6 @@ int main(int argc, char ** argv){
 		// FOR EACH LINE OF THE QUERY FILE
 		while(not query_file.eof()){
 			getline(query_file,line);
-			if(line[0]!= 'A' and line[0]!= 'C' and line[0]!= 'G' and line[0]!= 'T' ){
-				continue;
-			}
 			// I GOT THEIR INDICES
 			kmer_ids=ksl.query_sequence_hash(line);
 			for(uint64_t i(0);i<kmer_ids.size();++i){

--- a/blight.cpp
+++ b/blight.cpp
@@ -1007,13 +1007,13 @@ string kmer_Set_Light::kmer2str(kmer num){
 
 
 void kmer_Set_Light::create_mphf(uint begin_BC,uint end_BC){
-	//~ #pragma omp parallel  num_threads(coreNumber)
+	#pragma omp parallel  num_threads(coreNumber)
 		{
 		uint64_t anchors_number(0);
 		vector<kmer> anchors;
 		uint largest_bucket_anchor(0);
 		uint largest_bucket_nuc(0);
-		//~ #pragma omp for schedule(dynamic, number_bucket_per_mphf)
+		#pragma omp for schedule(dynamic, number_bucket_per_mphf.size())
 		for(uint BC=(begin_BC);BC<end_BC;++BC){
 			if(all_buckets[BC].nuc_minimizer!=0){
 				largest_bucket_nuc=max(largest_bucket_nuc,all_buckets[BC].nuc_minimizer);
@@ -1044,7 +1044,7 @@ void kmer_Set_Light::create_mphf(uint begin_BC,uint end_BC){
 				largest_MPHF=max(largest_MPHF,anchors.size());
 				anchors_number=anchors.size();
 				auto data_iterator3 = boomphf::range(static_cast<const kmer*>(&(anchors)[0]), static_cast<const kmer*>((&(anchors)[0])+anchors.size()));
-				all_mphf[BC/number_bucket_per_mphf].kmer_MPHF= new boomphf::mphf<kmer,hasher_t>(anchors.size(),data_iterator3,coreNumber,gammaFactor,false);
+				all_mphf[BC/number_bucket_per_mphf].kmer_MPHF= new boomphf::mphf<kmer,hasher_t>(anchors.size(),data_iterator3,gammaFactor,false);
 				anchors.clear();
 				largest_bucket_anchor=0;
 				largest_bucket_nuc=(0);

--- a/blight.cpp
+++ b/blight.cpp
@@ -230,9 +230,9 @@ uint32_t knuth_hash (uint32_t x){
 
 size_t hash2(int i1)
 {
-    size_t ret = i1;
-    ret *= 2654435761U;
-    return ret ^ 69;
+	size_t ret = i1;
+	ret *= 2654435761U;
+	return ret ^ 69;
 }
 
 
@@ -442,7 +442,7 @@ void kmer_Set_Light::create_super_buckets_extended(const string& input_file){
 	}
 	omp_lock_t lock[number_superbuckets];
 	for (int i=0; i<number_superbuckets; i++){
-        omp_init_lock(&(lock[i]));
+		omp_init_lock(&(lock[i]));
 	}
 	#pragma omp parallel num_threads(coreNumber)
 	{
@@ -597,7 +597,7 @@ void kmer_Set_Light::create_super_buckets_regular(const string& input_file){
 	}
 	omp_lock_t lock[number_superbuckets];
 	for (int i=0; i<number_superbuckets; i++){
-        omp_init_lock(&(lock[i]));
+		omp_init_lock(&(lock[i]));
 	}
 	#pragma omp parallel num_threads(coreNumber)
 	{

--- a/blight.cpp
+++ b/blight.cpp
@@ -518,7 +518,7 @@ void kmer_Set_Light::abundance_minimizer_construct(const string& input_file){
 			}
 		}
 	}
-	for(uint i(0);i<minimizer_number;++i){
+	for(uint i(0);i<minimizer_number.size();++i){
 		abundance_minimizer[i]=(uint8_t)(log2(abundance_minimizer_temp[i])*8);
 		//~ abundance_minimizer[i]=(abundance_minimizer_temp[i]);
 	}
@@ -536,13 +536,13 @@ void kmer_Set_Light::create_super_buckets_extended(const string& input_file){
 		exit(1);
 	}
 	vector<ostream*> out_files;
-	for(uint i(0);i<number_superbuckets;++i){
+	for(uint i(0);i<number_superbuckets.size();++i){
 		//~ auto out =new ofstream("_out"+to_string(i));
 		auto out =new zstr::ofstream("_out"+to_string(i));
 		out_files.push_back(out);
 	}
-	omp_lock_t lock[number_superbuckets];
-	for (int i=0; i<number_superbuckets; i++){
+	omp_lock_t lock[number_superbuckets.size()];
+	for (uint i=0; i<number_superbuckets.size(); i++){
 		omp_init_lock(&(lock[i]));
 	}
 	#pragma omp parallel num_threads(coreNumber)
@@ -557,7 +557,7 @@ void kmer_Set_Light::create_super_buckets_extended(const string& input_file){
 			}
 			//FOREACH UNITIG
 			if(not ref.empty() and not useless.empty()){
-				old_minimizer=minimizer=minimizer_number_graph;
+				old_minimizer=minimizer=minimizer_number_graph.size();
 				uint last_position(0);
 				//FOREACH KMER
 				kmer seq(str2num(ref.substr(0,k))),rcSeq(rcb(seq,k)),canon(min_k(seq,rcSeq));
@@ -615,7 +615,7 @@ void kmer_Set_Light::create_super_buckets_extended(const string& input_file){
 		}
 	}
 	delete inUnitigs;
-	for(uint i(0);i<number_superbuckets;++i){
+	for(uint i(0);i<number_superbuckets.size();++i){
 		*out_files[i]<<flush;
 		delete(out_files[i]);
 	}
@@ -623,7 +623,7 @@ void kmer_Set_Light::create_super_buckets_extended(const string& input_file){
 	bucketSeq.shrink_to_fit();
 	uint64_t i(0),total_pos_size(0);
 	uint max_bucket_mphf(0);
-	for(uint BC(0);BC<minimizer_number;++BC){
+	for(uint BC(0);BC<minimizer_number.size();++BC){
 		all_buckets[BC].start=i;
 		all_buckets[BC].current_pos=i;
 		i+=all_buckets[BC].nuc_minimizer;
@@ -691,13 +691,13 @@ void kmer_Set_Light::create_super_buckets_regular(const string& input_file){
 		exit(1);
 	}
 	vector<ostream*> out_files;
-	for(uint i(0);i<number_superbuckets;++i){
+	for(uint i(0);i<number_superbuckets.size();++i){
 		//~ auto out =new ofstream("_out"+to_string(i));
 		auto out =new zstr::ofstream("_out"+to_string(i));
 		out_files.push_back(out);
 	}
-	omp_lock_t lock[number_superbuckets];
-	for (int i=0; i<number_superbuckets; i++){
+	omp_lock_t lock[number_superbuckets.size()];
+	for (uint i=0; i<number_superbuckets.size(); i++){
 		omp_init_lock(&(lock[i]));
 	}
 	#pragma omp parallel num_threads(coreNumber)
@@ -712,7 +712,7 @@ void kmer_Set_Light::create_super_buckets_regular(const string& input_file){
 			}
 			//FOREACH UNITIG
 			if(not ref.empty() and not useless.empty()){
-				old_minimizer=minimizer=minimizer_number_graph;
+				old_minimizer=minimizer=minimizer_number_graph.size();
 				uint last_position(0);
 				//FOREACH KMER
 				kmer seq(str2num(ref.substr(0,k))),rcSeq(rcb(seq,k)),canon(min_k(seq,rcSeq));
@@ -756,7 +756,7 @@ void kmer_Set_Light::create_super_buckets_regular(const string& input_file){
 		}
 	}
 	delete inUnitigs;
-	for(uint i(0);i<number_superbuckets;++i){
+	for(uint i(0);i<number_superbuckets.size();++i){
 		*out_files[i]<<flush;
 		delete(out_files[i]);
 	}
@@ -764,7 +764,7 @@ void kmer_Set_Light::create_super_buckets_regular(const string& input_file){
 	bucketSeq.shrink_to_fit();
 	uint64_t i(0),total_pos_size(0);
 	uint max_bucket_mphf(0);
-	for(uint BC(0);BC<minimizer_number;++BC){
+	for(uint BC(0);BC<minimizer_number.size();++BC){
 		all_buckets[BC].start=i;
 		all_buckets[BC].current_pos=i;
 		i+=all_buckets[BC].nuc_minimizer;
@@ -819,14 +819,13 @@ void kmer_Set_Light::str2bool(const string& str,uint mini){
 void kmer_Set_Light::read_super_buckets(const string& input_file){
 	uint64_t total_size(0);
 	//~ cout<<"go"<<endl;
-	uint number_superbuckets_by_buckets(minimizer_number/number_superbuckets);
 	#pragma omp parallel num_threads(1)
 	{
 		string useless,line;
 		#pragma omp for
-		for(uint SBC=0;SBC<number_superbuckets;++SBC){
+		for(uint SBC=0;SBC<number_superbuckets.size();++SBC){
 			//~ cout<<"go"<<endl;
-			uint BC(SBC*bucket_per_superBuckets);
+			uint BC(SBC*bucket_per_superBuckets.size());
 			auto in=new zstr::ifstream((input_file+to_string(SBC)));
 			while(not in->eof() and in-> good()){
 				useless="";
@@ -845,11 +844,11 @@ void kmer_Set_Light::read_super_buckets(const string& input_file){
 			delete in;
 			remove((input_file+to_string(SBC)).c_str());
 			//~ cout<<"go1"<<endl;
-			create_mphf(BC,BC+bucket_per_superBuckets);
+			create_mphf(BC,BC+bucket_per_superBuckets.size());
 			//~ cout<<"go2"<<endl;
-			fill_positions(BC,BC+bucket_per_superBuckets);
+			fill_positions(BC,BC+bucket_per_superBuckets.size());
 			//~ cout<<"go3"<<endl;
-			BC+=bucket_per_superBuckets;
+			BC+=bucket_per_superBuckets.size();
 			cout<<"-"<<flush;
 		}
 	}
@@ -1076,7 +1075,7 @@ uint32_t kmer_Set_Light::bool_to_int(uint n_bits_to_encode,uint64_t pos,uint64_t
 		}
 		acc<<=1;
 	}
-	return res*positions_to_check;
+	return res*positions_to_check.size();
 }
 
 
@@ -1397,7 +1396,7 @@ int32_t kmer_Set_Light::query_get_pos_unitig(const kmer canon,uint minimizer){
 			}else{
 				uint64_t j;
 				bool found(false);
-				for(j=(pos);j<pos+positions_to_check;++j){
+				for(j=(pos);j<pos+positions_to_check.size();++j){
 					seqR=update_kmer(j+k,minimizer,seqR);//can be avoided
 					rcSeqR=(rcb(seqR,k));
 					canonR=(min_k(seqR, rcSeqR));
@@ -1447,7 +1446,7 @@ int64_t kmer_Set_Light::query_get_hash(const kmer canon,uint minimizer){
 				//~ cout<<8<<endl;
 				uint64_t j;
 				bool found(false);
-				for(j=(pos);j<pos+positions_to_check;++j){
+				for(j=(pos);j<pos+positions_to_check.size();++j){
 					seqR=update_kmer(j+k,minimizer,seqR);//can be avoided
 					rcSeqR=(rcb(seqR,k));
 					canonR=(min_k(seqR, rcSeqR));

--- a/blight.cpp
+++ b/blight.cpp
@@ -703,7 +703,7 @@ void kmer_Set_Light::create_super_buckets_regular(const string& input_file){
 	#pragma omp parallel num_threads(coreNumber)
 	{
 		string ref,useless;
-		minimizer_type old_minimizer,minimizer,precise_minimizer,old_precise_minimizer;
+		minimizer_type old_minimizer,minimizer; //,precise_minimizer,old_precise_minimizer;
 		while(not inUnitigs->eof()){
 			#pragma omp critical(dataupdate)
 			{
@@ -715,14 +715,14 @@ void kmer_Set_Light::create_super_buckets_regular(const string& input_file){
 				old_minimizer=minimizer=minimizer_number_graph.size();
 				uint last_position(0);
 				//FOREACH KMER
-				kmer seq(str2num(ref.substr(0,k))),rcSeq(rcb(seq,k)),canon(min_k(seq,rcSeq));
+				kmer seq(str2num(ref.substr(0,k))),rcSeq(rcb(seq,k)); //canon(min_k(seq,rcSeq));
 				minimizer=regular_minimizer(seq);
 				old_minimizer=minimizer;
 				uint i(0);
 				for(;i+k<ref.size();++i){
 					updateK(seq,ref[i+k]);
 					updateRCK(rcSeq,ref[i+k]);
-					canon=(min_k(seq, rcSeq));
+					//canon=(min_k(seq, rcSeq));
 					//COMPUTE KMER MINIMIZER
 					minimizer=regular_minimizer(seq);
 					if(old_minimizer!=minimizer){
@@ -733,7 +733,7 @@ void kmer_Set_Light::create_super_buckets_regular(const string& input_file){
 						all_buckets[old_minimizer].nuc_minimizer+=(i-last_position+k);
 						#pragma omp atomic
 						all_mphf[old_minimizer/number_bucket_per_mphf].mphf_size+=(i-last_position+k)-k+1;
-						all_mphf[old_precise_minimizer/number_bucket_per_mphf].empty=false;
+						//all_mphf[old_precise_minimizer/number_bucket_per_mphf].empty=false;
 						#pragma omp atomic
 						total_nuc_number+=(i-last_position+k);
 						last_position=i+1;
@@ -750,7 +750,7 @@ void kmer_Set_Light::create_super_buckets_regular(const string& input_file){
 					total_nuc_number+=(ref.substr(last_position)).size();
 					#pragma omp atomic
 					all_mphf[old_minimizer/number_bucket_per_mphf].mphf_size+=(ref.substr(last_position)).size()-k+1;
-					all_mphf[old_precise_minimizer/number_bucket_per_mphf].empty=false;
+					//all_mphf[old_precise_minimizer/number_bucket_per_mphf].empty=false;
 				}
 			}
 		}
@@ -1009,7 +1009,6 @@ string kmer_Set_Light::kmer2str(kmer num){
 void kmer_Set_Light::create_mphf(uint begin_BC,uint end_BC){
 	#pragma omp parallel  num_threads(coreNumber)
 		{
-		uint64_t anchors_number(0);
 		vector<kmer> anchors;
 		uint largest_bucket_anchor(0);
 		uint largest_bucket_nuc(0);
@@ -1042,7 +1041,6 @@ void kmer_Set_Light::create_mphf(uint begin_BC,uint end_BC){
 			}
 			if((BC+1)%number_bucket_per_mphf==0 and not anchors.empty()){
 				largest_MPHF=max(largest_MPHF,anchors.size());
-				anchors_number=anchors.size();
 				auto data_iterator3 = boomphf::range(static_cast<const kmer*>(&(anchors)[0]), static_cast<const kmer*>((&(anchors)[0])+anchors.size()));
 				all_mphf[BC/number_bucket_per_mphf].kmer_MPHF= new boomphf::mphf<kmer,hasher_t>(anchors.size(),data_iterator3,gammaFactor,false);
 				anchors.clear();

--- a/blight.cpp
+++ b/blight.cpp
@@ -815,10 +815,10 @@ void kmer_Set_Light::str2bool(const string& str,uint mini){
 void kmer_Set_Light::read_super_buckets(const string& input_file){
 	uint64_t total_size(0);
 	//~ cout<<"go"<<endl;
-	#pragma omp parallel num_threads(1)
+	//#pragma omp parallel num_threads(1)
 	{
 		string useless,line;
-		#pragma omp for
+		//#pragma omp for
 		for(uint SBC=0;SBC<number_superbuckets.size();++SBC){
 			//~ cout<<"go"<<endl;
 			uint BC(SBC*bucket_per_superBuckets.size());
@@ -831,9 +831,9 @@ void kmer_Set_Light::read_super_buckets(const string& input_file){
 					useless=useless.substr(1);
 					uint minimizer(stoi(useless));
 					str2bool(line,minimizer);
-					#pragma omp atomic
+					//#pragma omp atomic
 					number_kmer+=line.size()-k+1;
-					#pragma omp atomic
+					//#pragma omp atomic
 					number_super_kmer++;
 				}
 			}
@@ -1089,7 +1089,7 @@ void kmer_Set_Light::fill_positions(uint begin_BC,uint end_BC){
 						if((j+k)<all_buckets[BC].nuc_minimizer){
 							seq=(get_kmer(BC,j+1)),rcSeq=(rcb(seq,k)),canon=(min_k(seq,rcSeq));
 							//~ cout<<"go6"<<endl;
-							#pragma omp critical(dataupdate)
+							//#pragma omp critical(dataupdate)
 							{
 								int_to_bool(n_bits_to_encode,(j+1)/positions_to_check,all_mphf[BC/number_bucket_per_mphf].kmer_MPHF->lookup(canon),all_mphf[BC/number_bucket_per_mphf].start);
 							}
@@ -1103,7 +1103,7 @@ void kmer_Set_Light::fill_positions(uint begin_BC,uint end_BC){
 						//~ cout<<"7.2"<<endl;
 						//~ cout<<BC<<endl;
 						//~ cout<<all_mphf.size()<<endl;
-						#pragma omp critical(dataupdate)
+						//#pragma omp critical(dataupdate)
 						{
 							int_to_bool(n_bits_to_encode,(j+1)/positions_to_check,all_mphf[BC/number_bucket_per_mphf].kmer_MPHF->lookup(canon),all_mphf[BC/number_bucket_per_mphf].start);
 						}

--- a/blight.cpp
+++ b/blight.cpp
@@ -136,6 +136,35 @@ kmer str2num(const string& str){
 }
 
 
+inline uint32_t revhash ( uint32_t x ) {
+	x = ( ( x >> 16 ) ^ x ) * 0x2c1b3c6d;
+	x = ( ( x >> 16 ) ^ x ) * 0x297a2d39;
+	x = ( ( x >> 16 ) ^ x );
+	return x;
+}
+
+inline uint32_t unrevhash ( uint32_t x ) {
+	x = ( ( x >> 16 ) ^ x ) * 0x0cf0b109; // PowerMod[0x297a2d39, -1, 2^32]
+	x = ( ( x >> 16 ) ^ x ) * 0x64ea2d65;
+	x = ( ( x >> 16 ) ^ x );
+	return x;
+}
+
+
+inline uint64_t revhash ( uint64_t x ) {
+	x = ( ( x >> 32 ) ^ x ) * 0xD6E8FEB86659FD93;
+	x = ( ( x >> 32 ) ^ x ) * 0xD6E8FEB86659FD93;
+	x = ( ( x >> 32 ) ^ x );
+	return x;
+}
+
+inline uint64_t unrevhash ( uint64_t x ) {
+	x = ( ( x >> 32 ) ^ x ) * 0xCFEE444D8B59A89B;
+	x = ( ( x >> 32 ) ^ x ) * 0xCFEE444D8B59A89B;
+	x = ( ( x >> 32 ) ^ x );
+	return x;
+}
+
 
 //~ uint64_t xs(uint64_t y){
 	//~ y^=(y<<13); y^=(y>>17);y=(y^=(y<<15)); return y;
@@ -143,11 +172,13 @@ kmer str2num(const string& str){
 //~ uint64_t xs(uint64_t y){
 	//~ return y;
 //~ }
-uint64_t xs(uint32_t y){
-	uint64_t z(0);
-	MurmurHash3_x86_32 ( &y, 4, 17869, &z);
-	return z;
-}
+// uint64_t xs(uint32_t y){
+// 	uint64_t z(0);
+// 	MurmurHash3_x86_32 ( &y, 4, 17869, &z);
+// 	return z;
+// }
+template<typename T>
+inline T xs(const T& x) { return revhash(x); }
 
 
 

--- a/blight.h
+++ b/blight.h
@@ -154,7 +154,7 @@ public:
 			all_mphf[i].mphf_size=0;
 			all_mphf[i].bit_to_encode=0;
 			all_mphf[i].start=0;
-			all_mphf[i].empty=true;
+			all_mphf[i].empty=false;
 		}
 	}
 


### PR DESCRIPTION
Most gains in superbuckets creation were obtained by ensuring no div/mod instruction were emitted by the compiler where rshifts/maskings is possible (aad3b03)

The new hashes functions needs to be tested on bigger dataset I think (c091c29)

I needed to revert d70cf79 (91e3c18) as something went terribly wrong.

The multi-threading in bbhash is removed in 3f4990c as it is not compatible with many MPHF, and IMO it was coded using unspeakable human body parts.

I managed to get good improvements on multi-threading but I have some doubts about the correctness as I don't know the exact workings of the algo (some things are exclusive in my mind but may not be & the other way around). See the blight.h part of 3f4990c and 4ed7f2f 

Ideally the `read_super_buckets()`'s loop should be parallelized instead of the `create_mphf()` & `fill_positions()` ones. For some reason `str2bool()` is doing non-exlusive access as if a minimizer is shared between superbuckets ?

Overall it went from
```
I use -g /home/piezo/data/cel.unitigs.fa -q /home/piezo/data/cel.unitigs.fa -k 31 -m  9 -n  0 -s  3 -t 4 -b 6
Super bucket created: 28.9634 seconds.
----------------------------------------------------------------
----------------------INDEX RECAP----------------------------
Kmer in graph: 94,006,920
Super Kmer in graph: 8,184,928
Average size of Super Kmer: 11
Total size of the partitionned graph: 339,554,760
Total size of the partitionned graph: 339,554,784
Largest MPHF: 543,527
Largest Bucket: 1,511,971
Size of the partitionned graph (MBytes): 80
Total Positions size (MBytes): 111
Size of the partitionned graph (bit per kmer): 7.22404
Total Positions size (bit per kmer): 9.92692
TOTAL Bits per kmer (without bbhash): 17.151
TOTAL Bits per kmer (with bbhash): 21.151
TOTAL Size estimated (MBytes): 237.028
Indexes created: 226.856 seconds.
The whole indexing took me 255.819 seconds.
-----------------------QUERY RECAP 2----------------------------
Good kmer: 93,995,065
Erroneous kmers: 0
Query performed: 94,006,897
The whole QUERY took me 68.7343 seconds.
I am glad you are here with me. Here at the end of all things.
./bench_blight -g ~/data/cel.unitigs.fa -q ~/data/cel.unitigs.fa -k 31 -t 4  635.37s user 195.82s system 255% cpu 5:24.72 total
```

to 
```
I use -g /home/piezo/data/cel.unitigs.fa -q /home/piezo/data/cel.unitigs.fa -k 31 -m  9 -n  0 -s  3 -t 4 -b 6
Super bucket created: 18.7371 seconds.
----------------------------------------------------------------
----------------------INDEX RECAP----------------------------
Kmer in graph: 94,006,920
Super Kmer in graph: 8,166,653
Average size of Super Kmer: 11
Total size of the partitionned graph: 339,006,510
Total size of the partitionned graph: 339,006,528
Largest MPHF: 1,905,164
Largest Bucket: 4,434,824
Size of the partitionned graph (MBytes): 80
Total Positions size (MBytes): 111
Size of the partitionned graph (bit per kmer): 7.21237
Total Positions size (bit per kmer): 9.97155
TOTAL Bits per kmer (without bbhash): 17.1839
TOTAL Bits per kmer (with bbhash): 21.1839
TOTAL Size estimated (MBytes): 237.398
Indexes created: 25.3978 seconds.
The whole indexing took me 44.1349 seconds.
-----------------------QUERY RECAP 2----------------------------
Good kmer: 93,981,062
Erroneous kmers: 0
Query performed: 94,006,897
The whole QUERY took me 23.331 seconds.
I am glad you are here with me. Here at the end of all things.
./bench_blight -g ~/data/cel.unitigs.fa -q ~/data/cel.unitigs.fa -k 31 -t 4  197.20s user 0.90s system 292% cpu 1:07.62 total
```

Note how the system time is spared from the horrendous `pthread_create()`s that were inflicted by bbhash...