### PR TITLE
Space improvements

### DIFF
--- a/bbhash.h
+++ b/bbhash.h
@@ -12,17 +12,10 @@
 #include <array>
 #include <unordered_map>
 #include <vector>
-#include <assert.h>
+#include "common.h"
 #include <sys/time.h>
 #include <string.h>
-#include <memory> // for make_shared
 #include <unistd.h>
-
-
-
-
-
-
 
 namespace boomphf {
 
@@ -95,7 +88,7 @@ namespace boomphf {
 		friend bool operator==(bfile_iterator const& lhs, bfile_iterator const& rhs)
 		{
 			if (!lhs._is || !rhs._is)  {  if (!lhs._is && !rhs._is) {  return true; } else {  return false;  } }
-			assert(lhs._is == rhs._is);
+			assert(lhs._is == rhs._is, "different input stream, not comparable");
 			return rhs._pos == lhs._pos;
 		}
 
@@ -168,30 +161,6 @@ namespace boomphf {
 		FILE * _is;
 	};
 
-
-
-
-	inline unsigned int popcount_32(unsigned int x)
-	{
-		unsigned int m1 = 0x55555555;
-		unsigned int m2 = 0x33333333;
-		unsigned int m4 = 0x0f0f0f0f;
-		unsigned int h01 = 0x01010101;
-		x -= (x >> 1) & m1;               /* put count of each 2 bits into those 2 bits */
-		x = (x & m2) + ((x >> 2) & m2);   /* put count of each 4 bits in */
-		x = (x + (x >> 4)) & m4;          /* put count of each 8 bits in partie droite  4bit piece*/
-		return (x * h01) >> 24;           /* returns left 8 bits of x + (x<<8) + ... */
-	}
-
-
-	inline unsigned int popcount_64(uint64_t x)
-	{
-		unsigned int low = x & 0xffffffff ;
-		unsigned int high = ( x >> 32LL) & 0xffffffff ;
-
-		return (popcount_32(low) + popcount_32(high));
-	}
-
 ////////////////////////////////////////////////////////////////
 #pragma mark -
 #pragma mark hasher
@@ -200,43 +169,23 @@ namespace boomphf {
 	typedef std::array<uint64_t,10> hash_set_t;
 	typedef std::array<uint64_t,2> hash_pair_t;
 
+/* alternative hash functor based on xorshift, taking a single hash functor as input.
+we need this 2-functors scheme because HashFunctors won't work with unordered_map.
+(rayan)
+*/
 
-
-	template <typename Item> class HashFunctors
+    // wrapper around HashFunctors to return only one value instead of 7
+    template <typename Item> class SingleHashFunctor
 	{
 	public:
-
-		/** Constructor.
-		 * \param[in] nbFct : number of hash functions to be used
-		 * \param[in] seed : some initialization code for defining the hash functions. */
-		HashFunctors ()
-		{
-			_nbFct = 7; // use 7 hash func
-			_user_seed = 0;
-			generate_hash_seed ();
-		}
-
-		//return one hash
-
-        uint64_t operator ()  (const Item& key, size_t idx)  const {  return hash64 (key, _seed_tab[idx]);  }
-
-        uint64_t hashWithSeed(const Item& key, uint64_t seed)  const {  return hash64 (key, seed);  }
-
-		//this one returns all the 7 hashes
-		//maybe use xorshift instead, for faster hash compute
-		hash_set_t operator ()  (const Item& key)
-		{
-			hash_set_t	 hset;
-
-			for(size_t ii=0;ii<10; ii++)
-			{
-				hset[ii] =  hash64 (key, _seed_tab[ii]);
-			}
-			return hset;
-		}
+		uint64_t operator ()  (const Item& key, uint64_t seed=0xAAAAAAAA55555555ULL) const  {  return hash64(key, seed);  }
 
 	private:
-		inline static uint64_t hash64 (const Item& key, uint64_t seed)
+		inline static uint64_t hash64 (uint64_t key, uint64_t seed) {
+			return hash_bis(key, seed);
+		}
+
+		inline static uint64_t hash64 (unsigned __int128& key, uint64_t seed)
 		{
 			return hash_bis ((uint64_t) (key >> 64), seed^0xAAAAAAAA55555555ULL)  ^  hash_bis ((uint64_t)key, seed^0xBBBBBBBB66666666ULL);
 		}
@@ -255,41 +204,6 @@ namespace boomphf {
 
 			return hash;
 		}
-
-		/* */
-		void generate_hash_seed ()
-		{
-			static const uint64_t rbase[MAXNBFUNC] =
-			{
-				0xAAAAAAAA55555555ULL,  0x33333333CCCCCCCCULL,  0x6666666699999999ULL,  0xB5B5B5B54B4B4B4BULL,
-				0xAA55AA5555335533ULL,  0x33CC33CCCC66CC66ULL,  0x6699669999B599B5ULL,  0xB54BB54B4BAA4BAAULL,
-				0xAA33AA3355CC55CCULL,  0x33663366CC99CC99ULL
-			};
-
-			for (size_t i=0; i<MAXNBFUNC; ++i)  {  _seed_tab[i] = rbase[i];  }
-			for (size_t i=0; i<MAXNBFUNC; ++i)  {  _seed_tab[i] = _seed_tab[i] * _seed_tab[(i+3) % MAXNBFUNC] + _user_seed ;  }
-		}
-
-		size_t _nbFct;
-
-		static const size_t MAXNBFUNC = 10;
-		uint64_t _seed_tab[MAXNBFUNC];
-		uint64_t _user_seed;
-	};
-
-/* alternative hash functor based on xorshift, taking a single hash functor as input.
-we need this 2-functors scheme because HashFunctors won't work with unordered_map.
-(rayan)
-*/
-
-    // wrapper around HashFunctors to return only one value instead of 7
-    template <typename Item> class SingleHashFunctor
-	{
-	public:
-		uint64_t operator ()  (const Item& key, uint64_t seed=0xAAAAAAAA55555555ULL) const  {  return hashFunctors.hashWithSeed(key, seed);  }
-
-	private:
-		HashFunctors<Item> hashFunctors;
 	};
 
 
@@ -410,15 +324,15 @@ we need this 2-functors scheme because HashFunctors won't work with unordered_ma
 
 	public:
 
-		bitVector() : _size(0)
+		bitVector() : _nwords(0)
 		{
 			_bitArray = nullptr;
 		}
 
-		bitVector(uint64_t n) : _size(n)
+		bitVector(uint64_t n) : _nwords(n >> 6)
 		{
-			_nchar  = (1ULL+n/64ULL);
-			_bitArray =  (uint64_t *) calloc (_nchar,sizeof(uint64_t));
+			n = (n + 63) / 64;
+			_bitArray =  (uint64_t *) calloc (_nwords,sizeof(uint64_t));
 		}
 
 		~bitVector()
@@ -430,11 +344,10 @@ we need this 2-functors scheme because HashFunctors won't work with unordered_ma
 		 //copy constructor
 		 bitVector(bitVector const &r)
 		 {
-			 _size =  r._size;
-			 _nchar = r._nchar;
+			 _nwords = r._nwords;
 			 _ranks = r._ranks;
-			 _bitArray = (uint64_t *) calloc (_nchar,sizeof(uint64_t));
-			 memcpy(_bitArray, r._bitArray, _nchar*sizeof(uint64_t) );
+			 _bitArray = (uint64_t *) calloc (_nwords,sizeof(uint64_t));
+			 memcpy(_bitArray, r._bitArray, _nwords*sizeof(uint64_t) );
 		 }
 
 		// Copy assignment operator
@@ -442,13 +355,12 @@ we need this 2-functors scheme because HashFunctors won't work with unordered_ma
 		{
 			if (&r != this)
 			{
-				_size =  r._size;
-				_nchar = r._nchar;
+				_nwords = r._nwords;
 				_ranks = r._ranks;
 				if(_bitArray != nullptr)
 					free(_bitArray);
-				_bitArray = (uint64_t *) calloc (_nchar,sizeof(uint64_t));
-				memcpy(_bitArray, r._bitArray, _nchar*sizeof(uint64_t) );
+				_bitArray = (uint64_t *) calloc (_nwords,sizeof(uint64_t));
+				memcpy(_bitArray, r._bitArray, _nwords*sizeof(uint64_t) );
 			}
 			return *this;
 		}
@@ -462,8 +374,7 @@ we need this 2-functors scheme because HashFunctors won't work with unordered_ma
 				if(_bitArray != nullptr)
 					free(_bitArray);
 
-				_size =  std::move (r._size);
-				_nchar = std::move (r._nchar);
+				_nwords = std::move (r._nwords);
 				_ranks = std::move (r._ranks);
 				_bitArray = r._bitArray;
 				r._bitArray = nullptr;
@@ -471,7 +382,7 @@ we need this 2-functors scheme because HashFunctors won't work with unordered_ma
 			return *this;
 		}
 		// Move constructor
-		bitVector(bitVector &&r) : _bitArray ( nullptr),_size(0)
+		bitVector(bitVector &&r) : _bitArray ( nullptr)
 		{
 			*this = std::move(r);
 		}
@@ -479,53 +390,50 @@ we need this 2-functors scheme because HashFunctors won't work with unordered_ma
 
 		void resize(uint64_t newsize)
 		{
-			//printf("bitvector resize from  %llu bits to %llu \n",_size,newsize);
-			_nchar  = (1ULL+newsize/64ULL);
-			_bitArray = (uint64_t *) realloc(_bitArray,_nchar*sizeof(uint64_t));
-			_size = newsize;
+			_nwords  = (newsize + 63) / 64;
+			_bitArray = (uint64_t *) realloc(_bitArray,_nwords*sizeof(uint64_t));
 		}
 
 		size_t size() const
 		{
-			return _size;
+			return _nwords * sizeof(uint64_t) * CHAR_BIT;
 		}
 
-		uint64_t bitSize() const {return (_nchar*64ULL + _ranks.capacity()*64ULL );}
+		uint64_t bitSize() const {return (_nwords*64ULL + _ranks.capacity()*64ULL );}
 
 		//clear whole array
 		void clear()
 		{
-			memset(_bitArray,0,_nchar*sizeof(uint64_t));
+			memset(_bitArray,0,_nwords*sizeof(uint64_t));
 		}
 
 		//clear collisions in interval, only works with start and size multiple of 64
-		void clearCollisions(uint64_t start, size_t size, bitVector * cc)
+		void clearCollisions(uint64_t start, size_t size, const bitVector& cc)
 		{
-			assert( (start & 63) ==0);
-			assert( (size & 63) ==0);
+			assume( (start & 63) ==0, "start must be a multple of 64");
+			assume( (size & 63) ==0, "siaz must be a multple of 64");
 			uint64_t ids = (start/64ULL);
+			assume( ids + (size/64ULL) <= _nwords, "clearCollisions called after start");
 			for(uint64_t ii =0;  ii< (size/64ULL); ii++ )
 			{
-				_bitArray[ids+ii] =  _bitArray[ids+ii] & (~ (cc->get64(ii)) );
+				_bitArray[ids+ii] =  _bitArray[ids+ii] & (~ (cc.get64(ii)) );
 			}
-
-			cc->clear();
 		}
 
 
 		//clear interval, only works with start and size multiple of 64
 		void clear(uint64_t start, size_t size)
 		{
-			assert( (start & 63) ==0);
-			assert( (size & 63) ==0);
+			assume( (start & 63) ==0, "start must be a multple of 64");
+			assume( (size & 63) ==0, "siaz must be a multple of 64");
 			memset(_bitArray + (start/64ULL),0,(size/64ULL)*sizeof(uint64_t));
 		}
 
 		//for debug purposes
 		void print() const
 		{
-			printf("bit array of size %lli: \n",_size);
-			for(uint64_t ii = 0; ii< _size; ii++)
+			printf("bit array of size %lli: \n",size());
+			for(uint64_t ii = 0; ii< size(); ii++)
 			{
 				if(ii%10==0)
 					printf(" (%llu) ",ii);
@@ -547,7 +455,7 @@ we need this 2-functors scheme because HashFunctors won't work with unordered_ma
 		{
 			//unsigned char * _bitArray8 = (unsigned char *) _bitArray;
 			//return (_bitArray8[pos >> 3ULL] >> (pos & 7 ) ) & 1;
-
+			assume(pos < size(), "pos=%llu > size()=%llu", pos,  size());
 			return (_bitArray[pos >> 6ULL] >> (pos & 63 ) ) & 1;
 
 		}
@@ -555,6 +463,7 @@ we need this 2-functors scheme because HashFunctors won't work with unordered_ma
 		//return old val and set to 1
 		uint64_t test_and_set(uint64_t pos)
 		{
+			assume(pos < size(), "pos=%llu > size()=%llu", pos,  size());
 			uint64_t& val = _bitArray[pos >> 6];
 			uint64_t oldval = val;
 			val = oldval | uint64_t(1) << (pos & 63);
@@ -566,21 +475,23 @@ we need this 2-functors scheme because HashFunctors won't work with unordered_ma
 			return (*this)[pos];
 		}
 
-		uint64_t get64(uint64_t cell64) const
+		uint64_t get64(uint64_t pos_64) const
 		{
-			return _bitArray[cell64];
+			assume(pos_64 < size(), "pos_64=%llu > size()/64=%llu", pos_64, _nwords);
+			return _bitArray[pos_64];
 		}
 
 		//set bit pos to 1
 		void set(uint64_t pos)
 		{
-			assert(pos<_size);
+			assume(pos < size(), "pos=%llu > size()=%llu", pos,  size());
 			_bitArray [pos >> 6] |= (uint64_t(1) << (pos & 63) ) ;
 		}
 
 		//set bit pos to 0
 		void reset(uint64_t pos)
 		{
+			assume(pos < size(), "pos=%llu > size()=%llu", pos,  size());
 			_bitArray [pos >> 6] &= ~(uint64_t(1) << (pos & 63) ) ;
 		}
 
@@ -588,14 +499,14 @@ we need this 2-functors scheme because HashFunctors won't work with unordered_ma
 		// add offset to  all ranks  computed
 		uint64_t build_ranks(uint64_t offset =0)
 		{
-			_ranks.reserve(2+ _size/_nb_bits_per_rank_sample);
+			_ranks.reserve(2+ size()/_nb_bits_per_rank_sample);
 
 			uint64_t curent_rank = offset;
-			for (size_t ii = 0; ii < _nchar; ii++) {
+			for (size_t ii = 0; ii < _nwords; ii++) {
 				if (((ii*64)  % _nb_bits_per_rank_sample) == 0) {
 					_ranks.push_back(curent_rank);
 				}
-				curent_rank +=  popcount_64(_bitArray[ii]);
+				curent_rank += __builtin_popcountll(_bitArray[ii]);
 			}
 
 			return curent_rank;
@@ -603,15 +514,16 @@ we need this 2-functors scheme because HashFunctors won't work with unordered_ma
 
 		uint64_t rank(uint64_t pos) const
 		{
+			assume(pos < size(), "pos=%llu > size()=%llu", pos,  size());
 			uint64_t word_idx = pos / 64ULL;
 			uint64_t word_offset = pos % 64;
 			uint64_t block = pos / _nb_bits_per_rank_sample;
 			uint64_t r = _ranks[block];
 			for (uint64_t w = block * _nb_bits_per_rank_sample / 64; w < word_idx; ++w) {
-				r += popcount_64( _bitArray[w] );
+				r += __builtin_popcountll( _bitArray[w] );
 			}
 			uint64_t mask = (uint64_t(1) << word_offset ) - 1;
-			r += popcount_64( _bitArray[word_idx] & mask);
+			r += __builtin_popcountll( _bitArray[word_idx] & mask);
 
 			return r;
 		}
@@ -620,9 +532,8 @@ we need this 2-functors scheme because HashFunctors won't work with unordered_ma
 
 		void save(std::ostream& os) const
 		{
-			os.write(reinterpret_cast<char const*>(&_size), sizeof(_size));
-			os.write(reinterpret_cast<char const*>(&_nchar), sizeof(_nchar));
-			os.write(reinterpret_cast<char const*>(_bitArray), (std::streamsize)(sizeof(uint64_t) * _nchar));
+			os.write(reinterpret_cast<char const*>(&_nwords), sizeof(_nwords));
+			os.write(reinterpret_cast<char const*>(_bitArray), (std::streamsize)(sizeof(uint64_t) * _nwords));
 			size_t sizer = _ranks.size();
 			os.write(reinterpret_cast<char const*>(&sizer),  sizeof(size_t));
 			os.write(reinterpret_cast<char const*>(_ranks.data()), (std::streamsize)(sizeof(_ranks[0]) * _ranks.size()));
@@ -630,10 +541,9 @@ we need this 2-functors scheme because HashFunctors won't work with unordered_ma
 
 		void load(std::istream& is)
 		{
-			is.read(reinterpret_cast<char*>(&_size), sizeof(_size));
-			is.read(reinterpret_cast<char*>(&_nchar), sizeof(_nchar));
-			this->resize(_size);
-			is.read(reinterpret_cast<char *>(_bitArray), (std::streamsize)(sizeof(uint64_t) * _nchar));
+			is.read(reinterpret_cast<char*>(&_nwords), sizeof(_nwords));
+			this->resize(_nwords << 6);
+			is.read(reinterpret_cast<char *>(_bitArray), (std::streamsize)(sizeof(uint64_t) * _nwords));
 
 			size_t sizer;
 			is.read(reinterpret_cast<char *>(&sizer),  sizeof(size_t));
@@ -644,12 +554,10 @@ we need this 2-functors scheme because HashFunctors won't work with unordered_ma
 
 	protected:
 		uint64_t*  _bitArray;
-		//uint64_t* _bitArray;
-		uint64_t _size;
-		uint64_t _nchar;
+		uint64_t _nwords;
 
 		 // epsilon =  64 / _nb_bits_per_rank_sample   bits
-		// additional size for rank is epsilon * _size
+		// additional size for rank is epsilon * size()
 		static const uint64_t _nb_bits_per_rank_sample = 512; //512 seems ok
 		std::vector<uint64_t> _ranks;
 	};
@@ -660,12 +568,6 @@ we need this 2-functors scheme because HashFunctors won't work with unordered_ma
 ////////////////////////////////////////////////////////////////
 
 
-	static inline uint64_t fastrange64(uint64_t word, uint64_t p) {
-		//return word %  p;
-
-		return (uint64_t)(((__uint128_t)word * (__uint128_t)p) >> 64);
-
-	}
 
 	class level{
 	public:
@@ -674,17 +576,23 @@ we need this 2-functors scheme because HashFunctors won't work with unordered_ma
 		~level() {
 		}
 
-		uint64_t get(uint64_t hash_raw)
-		{
-		//	uint64_t hashi =    hash_raw %  hash_domain; //
-			//uint64_t hashi = (uint64_t)(  ((__uint128_t) hash_raw * (__uint128_t) hash_domain) >> 64ULL);
-			uint64_t hashi = fastrange64(hash_raw,hash_domain);
-			return bitset.get(hashi);
+		static uint64_t fastrange64(uint64_t word, uint64_t p) {
+			//return word %  p;
+
+			return (uint64_t)(((__uint128_t)word * (__uint128_t)p) >> 64);
+		}
+
+		uint64_t hash2levelidx(uint64_t hash_raw) const {
+			return fastrange64( hash_raw, hash_domain);
+		}
+
+
+		uint64_t hash2idx(uint64_t hash_raw) const {
+			return hash2levelidx(hash_raw) + idx_begin;
 		}
 
 		uint64_t idx_begin;
 		uint64_t hash_domain;
-		bitVector  bitset;
 	};
 
 
@@ -694,28 +602,9 @@ we need this 2-functors scheme because HashFunctors won't work with unordered_ma
 ////////////////////////////////////////////////////////////////
 
 
-#define NBBUFF 10000
-//#define NBBUFF 2
-
-	template<typename Range,typename Iterator>
-	struct thread_args
-	{
-		void * boophf;
-		Range const * range;
-		std::shared_ptr<void> it_p; /* used to be "Iterator it" but because of fastmode, iterator is polymorphic; TODO: think about whether it should be a unique_ptr actually */
-		std::shared_ptr<void> until_p; /* to cache the "until" variable */
-		int level;
-	};
-
-	//forward declaration
-
-    template <typename elem_t, typename Hasher_t, typename Range, typename it_type>
-	void * thread_processLevel(void * args);
-
-
     /* Hasher_t returns a single hash when operator()(elem_t key) is called.
        if used with XorshiftHashFunctors, it must have the following operator: operator()(elem_t key, uint64_t seed) */
-    template <typename elem_t, typename Hasher_t>
+    template <typename elem_t, typename Hasher_t, unsigned _nb_levels=16>
 	class mphf {
 
         /* this mechanisms gets P hashes out of Hasher_t */
@@ -723,8 +612,16 @@ we need this 2-functors scheme because HashFunctors won't work with unordered_ma
        // typedef HashFunctors<elem_t> MultiHasher_t; // original code (but only works for int64 keys)  (seems to be as fast as the current xorshift)
 		//typedef IndepHashFunctors<elem_t,Hasher_t> MultiHasher_t; //faster than xorshift
 
+
+		struct buildState {
+			std::vector< elem_t > setLevelFastmode;
+			bitVector collisions_map;
+			unsigned fastModeLevel;
+			bool fast_mode;
+		};
+
 	public:
-		mphf() : _built(false)
+		mphf()
 		{}
 
 
@@ -736,61 +633,32 @@ we need this 2-functors scheme because HashFunctors won't work with unordered_ma
 
 		// allow perc_elem_loaded  elements to be loaded in ram for faster construction (default 3%), set to 0 to desactivate
 		template <typename Range>
-		mphf( size_t n, Range const& input_range, double gamma = 2.0 , bool writeEach = true, float perc_elem_loaded = 0.99) :
-		_gamma(gamma), _hash_domain(size_t(ceil(double(n) * gamma))), _nelem(n), _percent_elem_loaded_for_fastMode (perc_elem_loaded)
+		mphf( size_t n, Range const& input_range, double gamma = 2.0, float perc_elem_loaded = 0.99) :
+		_gamma(gamma), _nelem(n)
 		{
 			if(n ==0) return;
 
-			_fastmode = false;
+			buildState state = setup(perc_elem_loaded);
 
-			if(_percent_elem_loaded_for_fastMode > 0.0 )
-				_fastmode =true;
+			for(unsigned ii = 0; ii< _nb_levels; ii++)
+			{
+				processLevel(input_range,ii, state);
 
-			if(writeEach)
-			{
-				_writeEachLevel =true;
-				_fastmode = false;
-			}
-			else
-			{
-				_writeEachLevel = false;
+				bitset.clearCollisions(_levels[ii].idx_begin , _levels[ii].hash_domain , state.collisions_map);
+				state.collisions_map.clear();
 			}
 
-			setup();
-
-			uint64_t offset = 0;
-			for(int ii = 0; ii< _nb_levels; ii++)
-			{
-				_tempBitset =  new bitVector(_levels[ii].hash_domain); // temp collision bitarray for this level
-
-				processLevel(input_range,ii);
-
-				_levels[ii].bitset.clearCollisions(0 , _levels[ii].hash_domain , _tempBitset);
-
-				offset = _levels[ii].bitset.build_ranks(offset);
-
-				delete _tempBitset;
-			}
-
-			_lastbitsetrank = offset ;
+			_lastbitsetrank = bitset.build_ranks(0) ;
 
 			//printf("used temp ram for construction : %lli MB \n",setLevelFastmode.capacity()* sizeof(elem_t) /1024ULL/1024ULL);
-
-			std::vector<elem_t>().swap(setLevelFastmode);   // clear setLevelFastmode reallocating
-
-			_built = true;
 		}
 
 
 		uint64_t lookup(elem_t elem)
 		{
-			if(! _built) return ULLONG_MAX;
-
-			//auto hashes = _hasher(elem);
-			uint64_t non_minimal_hp,minimal_hp;
 
 
-			hash_pair_t bbhash;  int level;
+			hash_pair_t bbhash;  unsigned level;
 			uint64_t level_hash = getLevel(bbhash,elem,&level);
 
 			if( level == (_nb_levels-1))
@@ -803,23 +671,14 @@ we need this 2-functors scheme because HashFunctors won't work with unordered_ma
 				}
 				else
 				{
-					minimal_hp =  in_final_map->second + _lastbitsetrank;
+					uint64_t minimal_hp = in_final_map->second + _lastbitsetrank;
 					//printf("lookup %llu  level %i   --> %llu \n",elem,level,minimal_hp);
 
 					return minimal_hp;
 				}
-//				minimal_hp = _final_hash[elem] + _lastbitsetrank;
-//				return minimal_hp;
 			}
-			else
-			{
-				//non_minimal_hp =  level_hash %  _levels[level].hash_domain; // in fact non minimal hp would be  + _levels[level]->idx_begin
-				non_minimal_hp = fastrange64(level_hash,_levels[level].hash_domain);
-			}
-			minimal_hp = _levels[level].bitset.rank(non_minimal_hp );
-		//	printf("lookup %llu  level %i   --> %llu \n",elem,level,minimal_hp);
 
-			return minimal_hp;
+			return bitset.rank(_levels[level].hash2idx(level_hash));
 		}
 
 		uint64_t nbKeys() const
@@ -829,126 +688,77 @@ we need this 2-functors scheme because HashFunctors won't work with unordered_ma
 
 		uint64_t totalBitSize()
 		{
-
-			uint64_t totalsizeBitset = 0;
-			for(int ii=0; ii<_nb_levels; ii++)
-			{
-				totalsizeBitset += _levels[ii].bitset.bitSize();
-			}
-
-			uint64_t totalsize =  totalsizeBitset +  _final_hash.size()*42*8 ;  // unordered map takes approx 42B per elem [personal test] (42B with uint64_t key, would be larger for other type of elem)
-
-			printf("Bitarray    %12llu  bits (%.2f %%)   (array + ranks )\n",
-				   totalsizeBitset, 100*(float)totalsizeBitset/totalsize);
-			printf("final hash  %12lu  bits (%.2f %%) (nb in final hash %lu)\n",
-				   _final_hash.size()*42*8, 100*(float)(_final_hash.size()*42*8)/totalsize,
-				   _final_hash.size() );
-			return totalsize;
+			// unordered map takes approx 42B per elem [personal test] (42B with uint64_t key, would be larger for other type of elem)
+			return bitset.bitSize() + CHAR_BIT * (_final_hash.size()*42 + sizeof(mphf));
 		}
 
 		template <typename Range>  //typename Range,
-        void pthread_processLevel(const Range& range, int i)
+        inline void inner_processLevel(const Range& range, unsigned i, buildState& state)
 		{
-			uint64_t nb_done =0;
-			uint64_t writebuff =0;
-			std::vector< elem_t > myWriteBuff = {};
-			myWriteBuff.resize(NBBUFF);
-
+			uint64_t hashidx = 0;
+			uint64_t idxLevelsetLevelFastmode = 0;
 
 			for(const elem_t& val: range)
 			{
-				//printf("processing %llu  level %i\n",val, i);
-
-				//auto hashes = _hasher(val);
-				hash_pair_t bbhash;  int level;
+				hash_pair_t bbhash;  unsigned level;
 				uint64_t level_hash;
-				if(_writeEachLevel)
-					getLevel(bbhash,val,&level, i,i-1);
-				else
-					getLevel(bbhash,val,&level, i);
-
+				getLevel(bbhash,val,&level, i);
 
 				if(level == i) //insert into lvl i
 				{
-					if(_fastmode && i == _fastModeLevel)
+					if(state.fast_mode && i == state.fastModeLevel)
 					{
 
-						uint64_t idxl2 = _idxLevelsetLevelFastmode++;
+						uint64_t idxl2 = idxLevelsetLevelFastmode++;
 						//si depasse taille attendue pour setLevelFastmode, fall back sur slow mode mais devrait pas arriver si hash ok et proba avec nous
-						if(idxl2>= setLevelFastmode.size())
-							_fastmode = false;
-						else
-							setLevelFastmode[idxl2] = val; // create set for fast mode
+						if(idxl2>= state.setLevelFastmode.size()) {
+							state.fast_mode = false;
+						} else {
+							state.setLevelFastmode[idxl2] = val; // create set for fast mode
+						}
 					}
 
 					//insert to level i+1 : either next level of the cascade or final hash if last level reached
 					if(i == _nb_levels-1) //stop cascade here, insert into exact hash
 					{
 						// calc rank de fin  precedent level qq part, puis init hashidx avec ce rank, direct minimal, pas besoin inser ds bitset et rank
-						_final_hash[val] = _hashidx++;
+						_final_hash[val] = hashidx++;
 					}
 					else
 					{
-						//ils ont reach ce level
-						//insert elem into curr level on disk --> sera utilise au level+1 , (mais encore besoin filtre)
-
-						if(_writeEachLevel && i > 0 && i < _nb_levels -1)
-						{
-							if(writebuff>=NBBUFF)
-							{
-								fwrite(myWriteBuff.data(),sizeof(elem_t),writebuff,_currlevelFile);
-								writebuff = 0;
-							}
-
-								myWriteBuff[writebuff++] = val;
-
-						}
-
-						//computes next hash
 
 						if ( level == 0)
-							level_hash = _hasher.h0(bbhash,val);
+							level_hash = get_hasher().h0(bbhash,val);
 						else if ( level == 1)
-							level_hash = _hasher.h1(bbhash,val);
+							level_hash = get_hasher().h1(bbhash,val);
 						else
 						{
-							level_hash = _hasher.next(bbhash);
+							level_hash = get_hasher().next(bbhash);
 						}
-						insertIntoLevel(level_hash,i); //should be safe
+						insertIntoLevel(level_hash, i, state.collisions_map); //should be safe
 					}
 				}
-
-				nb_done++;
 			}
 
-
-			if(_writeEachLevel && writebuff>0)
+			if(state.fast_mode && i == state.fastModeLevel) //shrink to actual number of elements in set
 			{
-				//flush buffer
-				fwrite(myWriteBuff.data(),sizeof(elem_t),writebuff,_currlevelFile);
-				writebuff = 0;
+				//printf("\nresize setLevelFastmode to %lli \n",_idxLevelsetLevelFastmode);
+				state.setLevelFastmode.resize(idxLevelsetLevelFastmode);
 			}
-
 		}
 
 
 		void save(std::ostream& os) const
 		{
-
 			os.write(reinterpret_cast<char const*>(&_gamma), sizeof(_gamma));
-			os.write(reinterpret_cast<char const*>(&_nb_levels), sizeof(_nb_levels));
 			os.write(reinterpret_cast<char const*>(&_lastbitsetrank), sizeof(_lastbitsetrank));
 			os.write(reinterpret_cast<char const*>(&_nelem), sizeof(_nelem));
-			 for(int ii=0; ii<_nb_levels; ii++)
-			 {
-			  	_levels[ii].bitset.save(os);
-			 }
+			bitset.save(os);
 
 			//save final hash
 			size_t final_hash_size = _final_hash.size();
 
 			os.write(reinterpret_cast<char const*>(&final_hash_size), sizeof(size_t));
-
 
 			// typename std::unordered_map<elem_t,uint64_t,Hasher_t>::iterator
 			for (auto it = _final_hash.begin(); it != _final_hash.end(); ++it )
@@ -956,41 +766,17 @@ we need this 2-functors scheme because HashFunctors won't work with unordered_ma
 				os.write(reinterpret_cast<char const*>(&(it->first)), sizeof(elem_t));
 				os.write(reinterpret_cast<char const*>(&(it->second)), sizeof(uint64_t));
 			}
-
 		}
 
 		void load(std::istream& is)
 		{
-
 			is.read(reinterpret_cast<char*>(&_gamma), sizeof(_gamma));
-			is.read(reinterpret_cast<char*>(&_nb_levels), sizeof(_nb_levels));
 			is.read(reinterpret_cast<char*>(&_lastbitsetrank), sizeof(_lastbitsetrank));
 			is.read(reinterpret_cast<char*>(&_nelem), sizeof(_nelem));
-
-			_levels.resize(_nb_levels);
-
-
-			for(int ii=0; ii<_nb_levels; ii++)
-			{
-				//_levels[ii].bitset = new bitVector();
-				_levels[ii].bitset.load(is);
-			}
-
-
+			bitset.load(is);
 
 			//mini setup, recompute size of each level
-			_proba_collision = 1.0 -  pow(((_gamma*(double)_nelem -1 ) / (_gamma*(double)_nelem)),_nelem-1);
-			uint64_t previous_idx =0;
-			_hash_domain = (size_t)  (ceil(double(_nelem) * _gamma)) ;
-			for(int ii=0; ii<_nb_levels; ii++)
-			{
-				//_levels[ii] = new level();
-				_levels[ii].idx_begin = previous_idx;
-				_levels[ii].hash_domain =  (( (uint64_t) (_hash_domain * pow(_proba_collision,ii)) + 63) / 64 ) * 64;
-				if(_levels[ii].hash_domain == 0 )
-					_levels[ii].hash_domain  = 64 ;
-				previous_idx += _levels[ii].hash_domain;
-			}
+			configureLevels();
 
 			//restore final hash
 
@@ -1009,82 +795,86 @@ we need this 2-functors scheme because HashFunctors won't work with unordered_ma
 
 				_final_hash[key] = value;
 			}
-			_built = true;
 		}
 
 
 		private :
+		// Collision probability for the first level
+		double probaCollision() {
+			return 1.0 -  pow(((_gamma*(double)_nelem -1 ) / (_gamma*(double)_nelem)),_nelem-1);
+		}
 
-		void setup()
-		{
-			if(_fastmode)
-			{
-				setLevelFastmode.resize(_percent_elem_loaded_for_fastMode * (double)_nelem );
-			}
+		//Configure the levels and return the total size of the bitVector
+		uint64_t configureLevels() {
+			double proba_collision = probaCollision();
 
-
-			_proba_collision = 1.0 -  pow(((_gamma*(double)_nelem -1 ) / (_gamma*(double)_nelem)),_nelem-1);
-
-			double sum_geom =_gamma * ( 1.0 +  _proba_collision / (1.0 - _proba_collision));
-			//printf("proba collision %f  sum_geom  %f   \n",_proba_collision,sum_geom);
-
-			_nb_levels = 25;
-			_levels.resize(_nb_levels);
+			//double sum_geom =_gamma * ( 1.0 +  proba_collision / (1.0 - proba_collision));
+			//printf("proba collision %f  sum_geom  %f   \n",proba_collision,sum_geom);
 
 			//build levels
 			uint64_t previous_idx =0;
-			for(int ii=0; ii<_nb_levels; ii++)
+			size_t hash_domain = (size_t)  (ceil(double(_nelem) * _gamma)) ;
+			for(unsigned ii=0; ii<_nb_levels; ii++)
 			{
 
 				_levels[ii].idx_begin = previous_idx;
 
 				// round size to nearest superior multiple of 64, makes it easier to clear a level
-				_levels[ii].hash_domain =  (( (uint64_t) (_hash_domain * pow(_proba_collision,ii)) + 63) / 64 ) * 64;
+				_levels[ii].hash_domain =  (( (uint64_t) (hash_domain * pow(proba_collision,ii)) + 63) / 64 ) * 64;
 				if(_levels[ii].hash_domain == 0 ) _levels[ii].hash_domain  = 64 ;
 				previous_idx += _levels[ii].hash_domain;
 
-				//printf("build level %i bit array : start %12llu, size %12llu  ",ii,_levels[ii]->idx_begin,_levels[ii]->hash_domain );
-				//printf(" expected elems : %.2f %% total \n",100.0*pow(_proba_collision,ii));
+// 				printf("build level %i bit array : start %12llu, size %12llu  ",ii,_levels[ii].idx_begin,_levels[ii].hash_domain );
+// 				printf(" expected elems : %.2f %% total \n",100.0*pow(proba_collision,ii));
 
 			}
 
-			for(int ii=0; ii<_nb_levels; ii++)
+			return previous_idx;
+		}
+
+		buildState setup(float percent_elem_loaded_for_fastMode)
+		{
+			bitset = bitVector(configureLevels());
+			double proba_collision = probaCollision();
+			unsigned fastModeLevel = 0;
+			for(; fastModeLevel<_nb_levels ; fastModeLevel++)
 			{
-				 if(pow(_proba_collision,ii) < _percent_elem_loaded_for_fastMode)
+				 if((float)pow(proba_collision,fastModeLevel) < percent_elem_loaded_for_fastMode)
 				 {
-				 	_fastModeLevel = ii;
-				 	 //printf("fast mode level :  %i \n",ii);
 				 	break;
 				 }
 			}
+
+			return buildState {
+				.setLevelFastmode = std::vector<elem_t>(size_t(percent_elem_loaded_for_fastMode * (float)_nelem), elem_t{}),
+				.collisions_map = { _levels[0].hash_domain },
+				.fastModeLevel = fastModeLevel,
+				.fast_mode = true
+			};
 		}
 
 
 		//compute level and returns hash of last level reached
-		uint64_t getLevel(hash_pair_t & bbhash, elem_t val,int * res_level, int maxlevel = 100, int minlevel =0)
+		uint64_t getLevel(hash_pair_t & bbhash, elem_t val,unsigned * res_level, unsigned maxlevel = 100, unsigned minlevel =0)
 		//uint64_t getLevel(hash_pair_t & bbhash, elem_t val,int * res_level, int maxlevel = 100, int minlevel =0)
-
 		{
-			int level = 0;
+			unsigned level = 0;
 			uint64_t hash_raw=0;
 
-			for (int ii = 0; ii<(_nb_levels-1) &&  ii < maxlevel ; ii++ )
+			for (unsigned ii = 0; ii<(_nb_levels-1) &&  ii < maxlevel ; ii++ )
 			{
 
 				//calc le hash suivant
 				 if ( ii == 0)
-					hash_raw = _hasher.h0(bbhash,val);
+					hash_raw = get_hasher().h0(bbhash,val);
 				else if ( ii == 1)
-					hash_raw = _hasher.h1(bbhash,val);
+					hash_raw = get_hasher().h1(bbhash,val);
 				else
 				{
-					hash_raw = _hasher.next(bbhash);
+					hash_raw = get_hasher().next(bbhash);
 				}
 
-
-				if( ii >= minlevel && _levels[ii].get(hash_raw) ) //
-				//if(  _levels[ii].get(hash_raw) ) //
-
+				if( ii >= minlevel && bitset.get(_levels[ii].hash2idx(hash_raw)) )
 				{
 					break;
 				}
@@ -1098,147 +888,39 @@ we need this 2-functors scheme because HashFunctors won't work with unordered_ma
 
 
 		//insert into bitarray
-		void insertIntoLevel(uint64_t level_hash, int i)
+		void insertIntoLevel(uint64_t level_hash, unsigned i, bitVector& collisions_map)
 		{
-		//	uint64_t hashl =  level_hash % _levels[i].hash_domain;
-			uint64_t hashl = fastrange64( level_hash,_levels[i].hash_domain);
-
-			if( _levels[i].bitset.test_and_set(hashl) )
+			if(bitset.test_and_set(_levels[i].hash2idx(level_hash)))
 			{
-				_tempBitset->test_and_set(hashl);
+				collisions_map.test_and_set(_levels[i].hash2levelidx(level_hash));
 			}
-
 		}
 
 
 		//loop to insert into level i
 		template <typename Range>
-		void processLevel(Range const& input_range,int i)
+		void processLevel(Range const& input_range, unsigned i, buildState& state)
 		{
-			////alloc the bitset for this level
-			_levels[i].bitset =  bitVector(_levels[i].hash_domain); ;
-
-			//printf("---process level %i   wr %i fast %i ---\n",i,_writeEachLevel,_fastmode);
-
-			char fname_old[1000];
-			sprintf(fname_old,"temp_p%i_level_%i",_pid,i-2);
-
-			char fname_curr[1000];
-			sprintf(fname_curr,"temp_p%i_level_%i",_pid,i);
-
-			char fname_prev[1000];
-			sprintf(fname_prev,"temp_p%i_level_%i",_pid,i-1);
-
-			if(_writeEachLevel)
+			if(state.fast_mode && i >= (state.fastModeLevel+1))
 			{
-				//file management :
-
-				if(i>2) //delete previous file
-				{
-					unlink(fname_old);
-				}
-
-				if(i< _nb_levels-1 && i > 0 ) //create curr file
-				{
-					_currlevelFile = fopen(fname_curr,"w");
-				}
+				inner_processLevel(state.setLevelFastmode, i, state);
 			}
-
-			_hashidx = 0;
-			_idxLevelsetLevelFastmode =0;
-
-			if(_writeEachLevel && (i > 1))
-			{
-				pthread_processLevel(file_binary<elem_t>(fname_prev), i);
-			}
-
 			else
 			{
-				if(_fastmode && i >= (_fastModeLevel+1))
-				{
-					pthread_processLevel(setLevelFastmode, i);
-				}
-				else
-				{
-					pthread_processLevel(input_range,i);
-				}
+				inner_processLevel(input_range, i, state);
 			}
-			//printf("\ngoing to level %i  : %llu elems  %.2f %%  expected : %.2f %% \n",i,_cptLevel,100.0* _cptLevel/(float)_nelem,100.0* pow(_proba_collision,i) );
-
-			if(_fastmode && i == _fastModeLevel) //shrink to actual number of elements in set
-			{
-				//printf("\nresize setLevelFastmode to %lli \n",_idxLevelsetLevelFastmode);
-				setLevelFastmode.resize(_idxLevelsetLevelFastmode);
-			}
-
-			if(_writeEachLevel)
-			{
-				if(i< _nb_levels-1 && i>0)
-				{
-					fflush(_currlevelFile);
-					fclose(_currlevelFile);
-				}
-
-					if(i== _nb_levels- 1) //delete last file
-					{
-						unlink(fname_prev);
-					}
-			}
-
 		}
 
 	private:
-		//level ** _levels;
-		std::vector<level> _levels;
-		int _nb_levels;
-        MultiHasher_t _hasher;
-		bitVector * _tempBitset;
+		level _levels[_nb_levels];
+		std::unordered_map<elem_t,uint64_t,Hasher_t> _final_hash;
+		bitVector bitset;
 
 		double _gamma;
-		uint64_t _hash_domain;
 		uint64_t _nelem;
-        std::unordered_map<elem_t,uint64_t,Hasher_t> _final_hash;
-		uint64_t _hashidx;
-		double _proba_collision;
 		uint64_t _lastbitsetrank;
-		uint64_t _idxLevelsetLevelFastmode;
 
-		// fast build mode , requires  that _percent_elem_loaded_for_fastMode %   elems are loaded in ram
-		float _percent_elem_loaded_for_fastMode ;
-		bool _fastmode;
-		std::vector< elem_t > setLevelFastmode;
-	//	std::vector< elem_t > setLevelFastmode_next; // todo shrinker le set e nram a chaque niveau  ?
-
-		int _fastModeLevel;
-		bool _built;
-		bool _writeEachLevel;
-		FILE * _currlevelFile;
-		int _pid;
+		MultiHasher_t get_hasher() { return {}; }
 	};
-
-////////////////////////////////////////////////////////////////
-#pragma mark -
-#pragma mark threading
-////////////////////////////////////////////////////////////////
-
-
-    template <typename elem_t, typename Hasher_t, typename Range, typename it_type>
-	void * thread_processLevel(void * args)
-	{
-		if(args ==NULL) return NULL;
-
-		thread_args<Range,it_type> *targ = (thread_args<Range,it_type>*) args;
-
-		mphf<elem_t, Hasher_t>  * obw = (mphf<elem_t, Hasher_t > *) targ->boophf;
-		int level = targ->level;
-		std::vector<elem_t> buffer;
-		buffer.resize(NBBUFF);
-
-        std::shared_ptr<it_type> startit = std::static_pointer_cast<it_type>(targ->it_p);
-        std::shared_ptr<it_type> until_p = std::static_pointer_cast<it_type>(targ->until_p);
-
-		obw->pthread_processLevel(buffer, startit, until_p, level);
-
-		return NULL;
-	}
 }
+

--- a/bbhash.h
+++ b/bbhash.h
@@ -19,23 +19,6 @@
 
 namespace boomphf {
 
-
-	inline u_int64_t printPt( pthread_t pt) {
-	  unsigned char *ptc = (unsigned char*)(void*)(&pt);
-		u_int64_t res =0;
-	  for (size_t i=0; i<sizeof(pt); i++) {
-		  res+= (unsigned)(ptc[i]);
-	  }
-		return res;
-	}
-
-
-////////////////////////////////////////////////////////////////
-#pragma mark -
-#pragma mark utils
-////////////////////////////////////////////////////////////////
-
-
 	// iterator from disk file of u_int64_t with buffered read,   todo template
 	template <typename basetype>
 	class bfile_iterator : public std::iterator<std::forward_iterator_tag, basetype>{
@@ -155,7 +138,7 @@ namespace boomphf {
 
 		bfile_iterator<type_elem> end() const {return bfile_iterator<type_elem>(); }
 
-		size_t        size () const  {  return 0;  }//todo ?
+		size_t		size () const  {  return 0;  }//todo ?
 
 	private:
 		FILE * _is;
@@ -166,7 +149,6 @@ namespace boomphf {
 #pragma mark hasher
 ////////////////////////////////////////////////////////////////
 
-	typedef std::array<uint64_t,10> hash_set_t;
 	typedef std::array<uint64_t,2> hash_pair_t;
 
 /* alternative hash functor based on xorshift, taking a single hash functor as input.
@@ -174,8 +156,8 @@ we need this 2-functors scheme because HashFunctors won't work with unordered_ma
 (rayan)
 */
 
-    // wrapper around HashFunctors to return only one value instead of 7
-    template <typename Item> class SingleHashFunctor
+	// wrapper around HashFunctors to return only one value instead of 7
+	template <typename Item> class SingleHashFunctor
 	{
 	public:
 		uint64_t operator ()  (const Item& key, uint64_t seed=0xAAAAAAAA55555555ULL) const  {  return hash64(key, seed);  }
@@ -208,36 +190,36 @@ we need this 2-functors scheme because HashFunctors won't work with unordered_ma
 
 
 
-    template <typename Item, class SingleHasher_t> class XorshiftHashFunctors
-    {
-        /*  Xorshift128*
-            Written in 2014 by Sebastiano Vigna (vigna@acm.org)
+	template <typename Item, class SingleHasher_t> class XorshiftHashFunctors
+	{
+		/*  Xorshift128*
+			Written in 2014 by Sebastiano Vigna (vigna@acm.org)
 
-            To the extent possible under law, the author has dedicated all copyright
-            and related and neighboring rights to this software to the public domain
-            worldwide. This software is distributed without any warranty.
+			To the extent possible under law, the author has dedicated all copyright
+			and related and neighboring rights to this software to the public domain
+			worldwide. This software is distributed without any warranty.
 
-            See <http://creativecommons.org/publicdomain/zero/1.0/>. */
-        /* This is the fastest generator passing BigCrush without
-           systematic failures, but due to the relatively short period it is
-           acceptable only for applications with a mild amount of parallelism;
-           otherwise, use a xorshift1024* generator.
+			See <http://creativecommons.org/publicdomain/zero/1.0/>. */
+		/* This is the fastest generator passing BigCrush without
+		   systematic failures, but due to the relatively short period it is
+		   acceptable only for applications with a mild amount of parallelism;
+		   otherwise, use a xorshift1024* generator.
 
-           The state must be seeded so that it is not everywhere zero. If you have
-           a nonzero 64-bit seed, we suggest to pass it twice through
-           MurmurHash3's avalanching function. */
+		   The state must be seeded so that it is not everywhere zero. If you have
+		   a nonzero 64-bit seed, we suggest to pass it twice through
+		   MurmurHash3's avalanching function. */
 
-      //  uint64_t s[ 2 ];
+	  //  uint64_t s[ 2 ];
 
-        uint64_t next(uint64_t * s) {
-            uint64_t s1 = s[ 0 ];
-            const uint64_t s0 = s[ 1 ];
-            s[ 0 ] = s0;
-            s1 ^= s1 << 23; // a
-            return ( s[ 1 ] = ( s1 ^ s0 ^ ( s1 >> 17 ) ^ ( s0 >> 26 ) ) ) + s0; // b, c
-        }
+		uint64_t next(uint64_t * s) {
+			uint64_t s1 = s[ 0 ];
+			const uint64_t s0 = s[ 1 ];
+			s[ 0 ] = s0;
+			s1 ^= s1 << 23; // a
+			return ( s[ 1 ] = ( s1 ^ s0 ^ ( s1 >> 17 ) ^ ( s0 >> 26 ) ) ) + s0; // b, c
+		}
 
-        public:
+		public:
 
 
 		uint64_t h0(hash_pair_t  & s, const Item& key )
@@ -254,7 +236,7 @@ we need this 2-functors scheme because HashFunctors won't work with unordered_ma
 
 
 		//return next hash an update state s
-		uint64_t next(hash_pair_t  & s ) {
+		uint64_t next(hash_pair_t & s ) {
 			uint64_t s1 = s[ 0 ];
 			const uint64_t s0 = s[ 1 ];
 			s[ 0 ] = s0;
@@ -262,35 +244,21 @@ we need this 2-functors scheme because HashFunctors won't work with unordered_ma
 			return ( s[ 1 ] = ( s1 ^ s0 ^ ( s1 >> 17 ) ^ ( s0 >> 26 ) ) ) + s0; // b, c
 		}
 
-        //this one returns all the  hashes
-        hash_set_t operator ()  (const Item& key)
-        {
-			uint64_t s[ 2 ];
+		uint64_t hot_fun iter(const Item& key, hash_pair_t& s, size_t i) {
+			uint64_t h;
+			if(i == 0)
+				h = h0(s, key);
+			else if(i == 1)
+				h = h1(s, key);
+			else
+				h = next(s);
+			return h;
+		}
 
-            hash_set_t   hset;
+	private:
+		SingleHasher_t singleHasher;
+	};
 
-            hset[0] =  singleHasher (key, 0xAAAAAAAA55555555ULL);
-            hset[1] =  singleHasher (key, 0x33333333CCCCCCCCULL);
-
-            s[0] = hset[0];
-            s[1] = hset[1];
-
-            for(size_t ii=2;ii< 10 /* it's much better have a constant here, for inlining; this loop is super performance critical*/; ii++)
-            {
-                hset[ii] = next(s);
-            }
-
-            return hset;
-        }
-    private:
-        SingleHasher_t singleHasher;
-    };
-
-
-////////////////////////////////////////////////////////////////
-#pragma mark -
-#pragma mark iterators
-////////////////////////////////////////////////////////////////
 
 	template <typename Iterator>
 	struct iter_range
@@ -315,10 +283,6 @@ we need this 2-functors scheme because HashFunctors won't work with unordered_ma
 		return iter_range<Iterator>(begin, end);
 	}
 
-////////////////////////////////////////////////////////////////
-#pragma mark -
-#pragma mark BitVector
-////////////////////////////////////////////////////////////////
 
 	class bitVector {
 
@@ -329,9 +293,10 @@ we need this 2-functors scheme because HashFunctors won't work with unordered_ma
 			_bitArray = nullptr;
 		}
 
-		bitVector(uint64_t n) : _nwords(n >> 6)
+		bitVector(uint64_t n)
 		{
 			n = (n + 63) / 64;
+			_nwords = n;
 			_bitArray =  (uint64_t *) calloc (_nwords,sizeof(uint64_t));
 		}
 
@@ -390,8 +355,11 @@ we need this 2-functors scheme because HashFunctors won't work with unordered_ma
 
 		void resize(uint64_t newsize)
 		{
-			_nwords  = (newsize + 63) / 64;
-			_bitArray = (uint64_t *) realloc(_bitArray,_nwords*sizeof(uint64_t));
+			uint64_t new_nwords  = (newsize + 63) / 64;
+			if(new_nwords > _nwords) {
+				_bitArray = (uint64_t *) realloc(_bitArray,_nwords*sizeof(uint64_t));
+			}
+			_nwords = new_nwords;
 		}
 
 		size_t size() const
@@ -497,12 +465,15 @@ we need this 2-functors scheme because HashFunctors won't work with unordered_ma
 
 		//return value of  last rank
 		// add offset to  all ranks  computed
-		uint64_t build_ranks(uint64_t offset =0)
+		uint64_t build_ranks(uint64_t upto, uint64_t offset =0)
 		{
-			_ranks.reserve(2+ size()/_nb_bits_per_rank_sample);
+			assume(upto <= size(), "build_ranks: upto=%llu > size()=%llu", upto, size());
+			const uint64_t max_idx = (upto + 63)/64;
+			assume(max_idx <= _nwords, "build_ranks: max_idx=%llu > _nwords=%llu", max_idx, _nwords);
+			_ranks.reserve(2+ upto/_nb_bits_per_rank_sample);
 
 			uint64_t curent_rank = offset;
-			for (size_t ii = 0; ii < _nwords; ii++) {
+			for (size_t ii = 0; ii < max_idx; ii++) {
 				if (((ii*64)  % _nb_bits_per_rank_sample) == 0) {
 					_ranks.push_back(curent_rank);
 				}
@@ -562,18 +533,26 @@ we need this 2-functors scheme because HashFunctors won't work with unordered_ma
 		std::vector<uint64_t> _ranks;
 	};
 
-////////////////////////////////////////////////////////////////
-#pragma mark -
-#pragma mark level
-////////////////////////////////////////////////////////////////
 
 
 
-	class level{
-	public:
-		level(){ }
+	/* Hasher_t returns a single hash when operator()(elem_t key) is called.
+	   if used with XorshiftHashFunctors, it must have the following operator: operator()(elem_t key, uint64_t seed) */
+	template <typename elem_t, typename Hasher_t, unsigned _nb_levels=16>
+	class mphf {
+		/* this mechanisms gets P hashes out of Hasher_t */
+		typedef XorshiftHashFunctors<elem_t,Hasher_t> MultiHasher_t ;
 
-		~level() {
+		struct buildState {
+			bitVector accommodated;
+			bitVector collisions_map;
+		};
+
+
+	struct levelIndexer {
+		levelIndexer(){ }
+
+		~levelIndexer() {
 		}
 
 		static uint64_t fastrange64(uint64_t word, uint64_t p) {
@@ -591,163 +570,196 @@ we need this 2-functors scheme because HashFunctors won't work with unordered_ma
 			return hash2levelidx(hash_raw) + idx_begin;
 		}
 
+		uint64_t endidx() const {
+			return idx_begin + hash_domain;
+		}
+
 		uint64_t idx_begin;
 		uint64_t hash_domain;
 	};
-
-
-////////////////////////////////////////////////////////////////
-#pragma mark -
-#pragma mark mphf
-////////////////////////////////////////////////////////////////
-
-
-    /* Hasher_t returns a single hash when operator()(elem_t key) is called.
-       if used with XorshiftHashFunctors, it must have the following operator: operator()(elem_t key, uint64_t seed) */
-    template <typename elem_t, typename Hasher_t, unsigned _nb_levels=16>
-	class mphf {
-
-        /* this mechanisms gets P hashes out of Hasher_t */
-        typedef XorshiftHashFunctors<elem_t,Hasher_t> MultiHasher_t ;
-       // typedef HashFunctors<elem_t> MultiHasher_t; // original code (but only works for int64 keys)  (seems to be as fast as the current xorshift)
-		//typedef IndepHashFunctors<elem_t,Hasher_t> MultiHasher_t; //faster than xorshift
-
-
-		struct buildState {
-			std::vector< elem_t > setLevelFastmode;
-			bitVector collisions_map;
-			unsigned fastModeLevel;
-			bool fast_mode;
-		};
 
 	public:
 		mphf()
 		{}
 
-
-		~mphf()
-		{
-
-		}
-
-
-		// allow perc_elem_loaded  elements to be loaded in ram for faster construction (default 3%), set to 0 to desactivate
 		template <typename Range>
-		mphf( size_t n, Range const& input_range, double gamma = 2.0, float perc_elem_loaded = 0.99) :
+		mphf( size_t n, Range const& input_range, double gamma = 2.0) :
 		_gamma(gamma), _nelem(n)
 		{
-			if(n ==0) return;
+			if(n == 0) return;
 
-			buildState state = setup(perc_elem_loaded);
+			bitset = bitVector(configureLevels());
 
-			for(unsigned ii = 0; ii< _nb_levels; ii++)
-			{
-				processLevel(input_range,ii, state);
+			buildState state = {
+				.accommodated = bitVector(_nelem),
+				.collisions_map = bitVector(_levels[0].hash_domain),
+			};
 
-				bitset.clearCollisions(_levels[ii].idx_begin , _levels[ii].hash_domain , state.collisions_map);
-				state.collisions_map.clear();
+			unsigned level = 0;
+			for(; ; level++) {
+				if(level < _nb_levels) {
+					if(processLevel(input_range, level, state)) {
+						continue; // Some keys collided, needs another level
+					} else {
+						break;
+					}
+				} else {
+					processFallbackLevel(input_range, state);
+					level = _nb_levels - 1;
+					break;
+				}
 			}
-
-			_lastbitsetrank = bitset.build_ranks(0) ;
-
-			//printf("used temp ram for construction : %lli MB \n",setLevelFastmode.capacity()* sizeof(elem_t) /1024ULL/1024ULL);
+			_lastbitsetrank = bitset.build_ranks(_levels[level].endidx());
 		}
 
-
-		uint64_t lookup(elem_t elem)
+		uint64_t lookup(elem_t elem) const
 		{
-
-
 			hash_pair_t bbhash;  unsigned level;
-			uint64_t level_hash = getLevel(bbhash,elem,&level);
+			uint64_t bit_idx = getLevel(elem, level, bbhash);
 
-			if( level == (_nb_levels-1))
-			{
-				auto in_final_map  = _final_hash.find (elem);
-				if ( in_final_map == _final_hash.end() )
+			if(level <= _nb_levels) {
+				return bitset.rank(bit_idx);
+			} else {
+				auto in_final_map = _final_hash.find(elem);
+				if (in_final_map != _final_hash.end())
 				{
-					//elem was not in orignal set of keys
-					return ULLONG_MAX; //  means elem not in set
-				}
-				else
-				{
-					uint64_t minimal_hp = in_final_map->second + _lastbitsetrank;
-					//printf("lookup %llu  level %i   --> %llu \n",elem,level,minimal_hp);
-
-					return minimal_hp;
+					return in_final_map->second + _lastbitsetrank;
+				} else {
+					// elem was not in orignal set of keys
+					assert(false, "not in final map");
+					return ULLONG_MAX; // means elem not in set
 				}
 			}
-
-			return bitset.rank(_levels[level].hash2idx(level_hash));
+			return bitset.rank(bit_idx);
 		}
 
 		uint64_t nbKeys() const
 		{
-            return _nelem;
-        }
+			return _nelem;
+		}
 
-		uint64_t totalBitSize()
+		uint64_t totalBitSize() const
 		{
 			// unordered map takes approx 42B per elem [personal test] (42B with uint64_t key, would be larger for other type of elem)
 			return bitset.bitSize() + CHAR_BIT * (_final_hash.size()*42 + sizeof(mphf));
 		}
 
-		template <typename Range>  //typename Range,
-        inline void inner_processLevel(const Range& range, unsigned i, buildState& state)
-		{
-			uint64_t hashidx = 0;
-			uint64_t idxLevelsetLevelFastmode = 0;
+	private:
 
-			for(const elem_t& val: range)
+		//Configure the levels and return the total size of the bitVector
+		uint64_t configureLevels() {
+			double proba_collision = 1.0 -  pow(((_gamma*(double)_nelem -1 ) / (_gamma*(double)_nelem)),_nelem-1);
+
+			//double sum_geom =_gamma * ( 1.0 +  proba_collision / (1.0 - proba_collision));
+			//printf("proba collision %f  sum_geom  %f   \n",proba_collision,sum_geom);
+
+			uint64_t previous_idx =0;
+			size_t hash_domain = (size_t)  (ceil(double(_nelem) * _gamma)) ;
+			for(unsigned ii=0; ii<_nb_levels; ii++)
 			{
-				hash_pair_t bbhash;  unsigned level;
-				uint64_t level_hash;
-				getLevel(bbhash,val,&level, i);
 
-				if(level == i) //insert into lvl i
-				{
-					if(state.fast_mode && i == state.fastModeLevel)
-					{
+				_levels[ii].idx_begin = previous_idx;
 
-						uint64_t idxl2 = idxLevelsetLevelFastmode++;
-						//si depasse taille attendue pour setLevelFastmode, fall back sur slow mode mais devrait pas arriver si hash ok et proba avec nous
-						if(idxl2>= state.setLevelFastmode.size()) {
-							state.fast_mode = false;
-						} else {
-							state.setLevelFastmode[idxl2] = val; // create set for fast mode
-						}
-					}
+				// round size to nearest superior multiple of 64, makes it easier to clear a level
+				_levels[ii].hash_domain =  (( (uint64_t) (hash_domain * pow(proba_collision,ii)) + 63) / 64 ) * 64;
+				if(_levels[ii].hash_domain == 0 ) _levels[ii].hash_domain  = 64 ;
+				previous_idx += _levels[ii].hash_domain;
 
-					//insert to level i+1 : either next level of the cascade or final hash if last level reached
-					if(i == _nb_levels-1) //stop cascade here, insert into exact hash
-					{
-						// calc rank de fin  precedent level qq part, puis init hashidx avec ce rank, direct minimal, pas besoin inser ds bitset et rank
-						_final_hash[val] = hashidx++;
-					}
-					else
-					{
+// 				printf("build level %i bit array : start %12llu, size %12llu  ",ii,_levels[ii].idx_begin,_levels[ii].hash_domain );
+// 				printf(" expected elems : %.2f %% total \n",100.0*pow(proba_collision,ii));
+			}
 
-						if ( level == 0)
-							level_hash = get_hasher().h0(bbhash,val);
-						else if ( level == 1)
-							level_hash = get_hasher().h1(bbhash,val);
-						else
+			return previous_idx;
+		}
+
+		//compute level and returns bit vector position in the last level reached
+		uint64_t hot_fun getLevel(elem_t val, unsigned& level, hash_pair_t& bbhash, unsigned maxlevel = _nb_levels) const
+		{
+			uint64_t bit_idx = ULLONG_MAX;
+			assume(maxlevel <= _nb_levels, "getLevel: maxlevel=%u > _nb_levels=%u", maxlevel, _nb_levels);
+			for (level = 0; level < maxlevel ; level++ )
+			{
+				bit_idx = _levels[level].hash2idx(get_hasher().iter(val, bbhash, level));
+				if(bitset.get(bit_idx))
+					break;
+				else
+					continue;
+			}
+			return bit_idx;
+		}
+
+		template <typename Range>
+		bool flatten_fun processLevel(const Range& range, unsigned level, buildState& state) {
+			switch(level) {
+				case 0: return processLevel_(range, 0, state);
+				case 1: return processLevel_(range, 1, state);
+				default: return processLevel_(range, level, state);
+			}
+		}
+
+		template <typename Range>
+		bool processLevel_(const Range& range, unsigned level, buildState& state)
+		{
+			const levelIndexer& level_indexer = _levels[level];
+			if(level > 0)
+				state.collisions_map.clear(0, level_indexer.hash_domain);
+
+			bool did_collide = false;
+			size_t key_idx = 0;
+			for(auto it = std::begin(range) ; it != std::end(range) ; it++, key_idx++) {
+				// After level 2 we can skip keys that were found at stable positions in level 1
+				if(level >= 2 && state.accommodated.get(key_idx)) {
+					// This branch is not useless, it allows to inform the branch predictor
+					continue;
+				} else {
+					const elem_t& val = *it;
+					hash_pair_t bbhash; unsigned found_level;
+					getLevel(val, found_level, bbhash, level);
+					if(found_level < level) {
+						// Mark the key as accommodated in previous level, avoid rehasing it afterwards
+						state.accommodated.set(key_idx);
+					} else {
+						// Not found in previous levels => insert into this one
+						uint64_t level_hash = get_hasher().iter(val, bbhash, level);
+
+						// Put the key in the bit vector, checking for collisions
+						if(bitset.test_and_set(level_indexer.hash2idx(level_hash)))
 						{
-							level_hash = get_hasher().next(bbhash);
+							state.collisions_map.test_and_set(level_indexer.hash2levelidx(level_hash));
+							did_collide = true;
 						}
-						insertIntoLevel(level_hash, i, state.collisions_map); //should be safe
 					}
 				}
 			}
 
-			if(state.fast_mode && i == state.fastModeLevel) //shrink to actual number of elements in set
-			{
-				//printf("\nresize setLevelFastmode to %lli \n",_idxLevelsetLevelFastmode);
-				state.setLevelFastmode.resize(idxLevelsetLevelFastmode);
+			if(did_collide)
+				bitset.clearCollisions(level_indexer.idx_begin, level_indexer.hash_domain , state.collisions_map);
+
+			return did_collide;
+		}
+
+		template <typename Range>
+		inline void processFallbackLevel(const Range& range, buildState& state)
+		{
+			uint64_t hashidx = 0;
+			size_t key_idx = 0;
+			for(auto it = std::begin(range) ; it != std::end(range) ; it++, key_idx++) {
+				if(state.accommodated.get(key_idx)) {
+					// This branch is not useless, it allows to inform the branch predictor
+					continue;
+				} else {
+					const elem_t& val = *it;
+					hash_pair_t bbhash;  unsigned found_level;
+					getLevel(val, found_level, bbhash);
+					if(found_level >= _nb_levels) // Not in any level
+					{
+						_final_hash[val] = hashidx++;
+					}
+				}
 			}
 		}
 
-
+	public:
 		void save(std::ostream& os) const
 		{
 			os.write(reinterpret_cast<char const*>(&_gamma), sizeof(_gamma));
@@ -779,7 +791,6 @@ we need this 2-functors scheme because HashFunctors won't work with unordered_ma
 			configureLevels();
 
 			//restore final hash
-
 			_final_hash.clear();
 			size_t final_hash_size ;
 
@@ -797,122 +808,8 @@ we need this 2-functors scheme because HashFunctors won't work with unordered_ma
 			}
 		}
 
-
-		private :
-		// Collision probability for the first level
-		double probaCollision() {
-			return 1.0 -  pow(((_gamma*(double)_nelem -1 ) / (_gamma*(double)_nelem)),_nelem-1);
-		}
-
-		//Configure the levels and return the total size of the bitVector
-		uint64_t configureLevels() {
-			double proba_collision = probaCollision();
-
-			//double sum_geom =_gamma * ( 1.0 +  proba_collision / (1.0 - proba_collision));
-			//printf("proba collision %f  sum_geom  %f   \n",proba_collision,sum_geom);
-
-			//build levels
-			uint64_t previous_idx =0;
-			size_t hash_domain = (size_t)  (ceil(double(_nelem) * _gamma)) ;
-			for(unsigned ii=0; ii<_nb_levels; ii++)
-			{
-
-				_levels[ii].idx_begin = previous_idx;
-
-				// round size to nearest superior multiple of 64, makes it easier to clear a level
-				_levels[ii].hash_domain =  (( (uint64_t) (hash_domain * pow(proba_collision,ii)) + 63) / 64 ) * 64;
-				if(_levels[ii].hash_domain == 0 ) _levels[ii].hash_domain  = 64 ;
-				previous_idx += _levels[ii].hash_domain;
-
-// 				printf("build level %i bit array : start %12llu, size %12llu  ",ii,_levels[ii].idx_begin,_levels[ii].hash_domain );
-// 				printf(" expected elems : %.2f %% total \n",100.0*pow(proba_collision,ii));
-
-			}
-
-			return previous_idx;
-		}
-
-		buildState setup(float percent_elem_loaded_for_fastMode)
-		{
-			bitset = bitVector(configureLevels());
-			double proba_collision = probaCollision();
-			unsigned fastModeLevel = 0;
-			for(; fastModeLevel<_nb_levels ; fastModeLevel++)
-			{
-				 if((float)pow(proba_collision,fastModeLevel) < percent_elem_loaded_for_fastMode)
-				 {
-				 	break;
-				 }
-			}
-
-			return buildState {
-				.setLevelFastmode = std::vector<elem_t>(size_t(percent_elem_loaded_for_fastMode * (float)_nelem), elem_t{}),
-				.collisions_map = { _levels[0].hash_domain },
-				.fastModeLevel = fastModeLevel,
-				.fast_mode = true
-			};
-		}
-
-
-		//compute level and returns hash of last level reached
-		uint64_t getLevel(hash_pair_t & bbhash, elem_t val,unsigned * res_level, unsigned maxlevel = 100, unsigned minlevel =0)
-		//uint64_t getLevel(hash_pair_t & bbhash, elem_t val,int * res_level, int maxlevel = 100, int minlevel =0)
-		{
-			unsigned level = 0;
-			uint64_t hash_raw=0;
-
-			for (unsigned ii = 0; ii<(_nb_levels-1) &&  ii < maxlevel ; ii++ )
-			{
-
-				//calc le hash suivant
-				 if ( ii == 0)
-					hash_raw = get_hasher().h0(bbhash,val);
-				else if ( ii == 1)
-					hash_raw = get_hasher().h1(bbhash,val);
-				else
-				{
-					hash_raw = get_hasher().next(bbhash);
-				}
-
-				if( ii >= minlevel && bitset.get(_levels[ii].hash2idx(hash_raw)) )
-				{
-					break;
-				}
-
-				level++;
-			}
-
-			*res_level = level;
-			return hash_raw;
-		}
-
-
-		//insert into bitarray
-		void insertIntoLevel(uint64_t level_hash, unsigned i, bitVector& collisions_map)
-		{
-			if(bitset.test_and_set(_levels[i].hash2idx(level_hash)))
-			{
-				collisions_map.test_and_set(_levels[i].hash2levelidx(level_hash));
-			}
-		}
-
-
-		//loop to insert into level i
-		template <typename Range>
-		void processLevel(Range const& input_range, unsigned i, buildState& state)
-		{
-			if(state.fast_mode && i >= (state.fastModeLevel+1))
-			{
-				inner_processLevel(state.setLevelFastmode, i, state);
-			}
-			else
-			{
-				inner_processLevel(input_range, i, state);
-			}
-		}
-
 	private:
-		level _levels[_nb_levels];
+		levelIndexer _levels[_nb_levels];
 		std::unordered_map<elem_t,uint64_t,Hasher_t> _final_hash;
 		bitVector bitset;
 
@@ -920,7 +817,7 @@ we need this 2-functors scheme because HashFunctors won't work with unordered_ma
 		uint64_t _nelem;
 		uint64_t _lastbitsetrank;
 
-		MultiHasher_t get_hasher() { return {}; }
+		MultiHasher_t get_hasher() const { return {}; }
 	};
 }
 

--- a/bench_blight.cpp
+++ b/bench_blight.cpp
@@ -101,7 +101,7 @@ int main(int argc, char ** argv){
 		kmer_Set_Light ksl(k,m1,m2,m3,c,bit,ex);
 		ksl.construct_index(input);
 
-		ksl.file_query(query,false);
+		ksl.file_query(query);
 
 		//~ ksl.file_query(query,true);
 		//~ high_resolution_clock::time_point t4 = high_resolution_clock::now();

--- a/blight.cpp
+++ b/blight.cpp
@@ -1054,7 +1054,7 @@ void kmer_Set_Light::create_mphf(uint begin_BC,uint end_BC){
 			if((BC+1)%number_bucket_per_mphf==0 and not anchors.empty()){
 				largest_MPHF=max(largest_MPHF,anchors.size());
 				auto data_iterator3 = boomphf::range(static_cast<const kmer*>(&(anchors)[0]), static_cast<const kmer*>((&(anchors)[0])+anchors.size()));
-				all_mphf[BC/number_bucket_per_mphf].kmer_MPHF= new boomphf::mphf<kmer,hasher_t>(anchors.size(),data_iterator3,gammaFactor,false);
+				all_mphf[BC/number_bucket_per_mphf].kmer_MPHF= new boomphf::mphf<kmer,hasher_t>(anchors.size(),data_iterator3,gammaFactor);
 				anchors.clear();
 				largest_bucket_anchor=0;
 				largest_bucket_nuc=(0);

--- a/blight.cpp
+++ b/blight.cpp
@@ -15,7 +15,6 @@
 #include "blight.h"
 #include "zstr.hpp"
 #include <omp.h>
-#include "MurmurHash3.h"
 
 
 
@@ -24,7 +23,7 @@ using namespace chrono;
 
 
 
-kmer nuc2int(char c){
+inline kmer nuc2int(char c){
 	switch(c){
 		/*
 		case 'a': return 0;
@@ -44,7 +43,7 @@ kmer nuc2int(char c){
 
 
 
-kmer nuc2intrc(char c){
+inline kmer nuc2intrc(char c){
 	switch(c){
 		/*
 		case 'a': return 0;
@@ -64,7 +63,7 @@ kmer nuc2intrc(char c){
 
 
 
-uint number_miss(const string str1,const string str2){
+inline uint number_miss(const string str1,const string str2){
 	uint res(0);
 	for(uint i(0);i<str1.size();++i){
 		if(str1[i]!=str2[i]){
@@ -76,7 +75,7 @@ uint number_miss(const string str1,const string str2){
 
 
 
-string intToString(uint64_t n){
+inline string intToString(uint64_t n){
 	if(n<1000){
 		return to_string(n);
 	}
@@ -92,7 +91,7 @@ string intToString(uint64_t n){
 
 
 
-char revCompChar(char c) {
+inline char revCompChar(char c) {
 	switch (c) {
 		case 'A': return 'T';
 		case 'C': return 'G';
@@ -103,7 +102,7 @@ char revCompChar(char c) {
 
 
 
-string revComp(const string& s){
+inline  string revComp(const string& s){
 	string rc(s.size(),0);
 	for (int i((int)s.length() - 1); i >= 0; i--){
 		rc[s.size()-1-i] = revCompChar(s[i]);
@@ -113,13 +112,13 @@ string revComp(const string& s){
 
 
 
-string getCanonical(const string& str){
+inline string getCanonical(const string& str){
 	return (min(str,revComp(str)));
 }
 
 
 
-kmer str2num(const string& str){
+inline kmer str2num(const string& str){
 	kmer res(0);
 	for(uint i(0);i<str.size();i++){
 		res<<=2;
@@ -204,6 +203,7 @@ inline T xs(const T& x) { return revhash(x); }
 // See: https://stackoverflow.com/questions/34478328/the-best-way-to-shift-a-m128i
 inline __m128i mm_bitshift_left(__m128i x, unsigned count)
 {
+	assume(count < 128, "count=%u >= 128", count);
 	__m128i carry = _mm_slli_si128(x, 8);
 	if (count >= 64) //TODO: bench: Might be faster to skip this fast-path branch
 		return _mm_slli_epi64(carry, count-64);  // the non-carry part is all zero, so return early
@@ -216,6 +216,7 @@ inline __m128i mm_bitshift_left(__m128i x, unsigned count)
 
 inline __m128i mm_bitshift_right(__m128i x, unsigned count)
 {
+	assume(count < 128, "count=%u >= 128", count);
 	__m128i carry = _mm_srli_si128(x, 8);
 	if (count >= 64)
 		return _mm_srli_epi64(carry, count-64);  // the non-carry part is all zero, so return early
@@ -228,6 +229,7 @@ inline __m128i mm_bitshift_right(__m128i x, unsigned count)
 
 
 inline __uint128_t rcb(const __uint128_t& in, uint n){
+	assume(n <= 64, "n=%u > 64", n);
 	union kmer_u { __uint128_t k; __m128i m128i; uint64_t u64[2]; uint8_t u8[16];};
 	kmer_u res = { .k = in };
 	static_assert(sizeof(res) == sizeof(__uint128_t), "kmer sizeof mismatch");
@@ -253,6 +255,7 @@ inline __uint128_t rcb(const __uint128_t& in, uint n){
 }
 
 inline uint64_t rcb(uint64_t in, uint n) {
+	assume(n <= 32, "n=%u > 32", n);
 	// Complement, swap byte order
 	uint64_t res = __builtin_bswap64(~in);
 	// Swap nuc order in bytes
@@ -268,6 +271,7 @@ inline uint64_t rcb(uint64_t in, uint n) {
 }
 
 inline uint32_t rcb(uint32_t in, uint n) {
+	assume(n <= 16, "n=%u > 16", n);
 	// Complement, swap byte order
 	uint32_t res = __builtin_bswap32(~in);
 
@@ -300,7 +304,7 @@ void kmer_Set_Light::updateM(kmer& min, char nuc){
 
 
 
-kmer min_k (const kmer& k1,const kmer& k2){
+inline kmer min_k (const kmer& k1,const kmer& k2){
 	if(k1<=k2){
 		return k1;
 	}
@@ -323,13 +327,13 @@ void kmer_Set_Light::updateRCM(kmer& min, char nuc){
 
 
 
-uint32_t knuth_hash (uint32_t x){
+inline uint32_t knuth_hash (uint32_t x){
 	return x*2654435761;
 }
 
 
 
-size_t hash2(int i1)
+inline size_t hash2(int i1)
 {
 	size_t ret = i1;
 	ret *= 2654435761U;
@@ -361,7 +365,7 @@ extended_minimizer kmer_Set_Light::get_extended_minimizer_from_min(kmer seq, uin
 	}
 	res.fragile=res.suffix_fragile+res.prefix_fragile;
 	if(not res.fragile){
-		res.extended_mini=min(res.extended_mini,(uint32_t)rcb(res.extended_mini,m1));
+		res.extended_mini=min(res.extended_mini,rcb(res.extended_mini,m1));
 	}
 	//~ uint32_t rc(rcb(res.extended_mini,m1));
 	//~ if(rc<res.extended_mini){
@@ -392,14 +396,14 @@ extended_minimizer kmer_Set_Light::minimizer_and_more(kmer seq){
 	extended_minimizer res;
 	uint horrible_counter(0);
 	kmer seq2(seq);
-	uint32_t mini,mini2,mmer;
+	uint32_t mini,mmer;
 	mmer=seq%minimizer_number_graph;
-	mini=min(mmer,(uint32_t)rcb(mmer,minimizer_size_graph));
+	mini=min(mmer,rcb(mmer,minimizer_size_graph));
 	res=get_extended_minimizer_from_min(seq2,mini,0);
 	for(uint i(1);i<=k-minimizer_size_graph;i++){
 		seq>>=2;
 		mmer=seq%minimizer_number_graph;
-		mmer=min(mmer,(uint32_t)rcb(mmer,minimizer_size_graph));
+		mmer=min(mmer,rcb(mmer,minimizer_size_graph));
 		if((xs(mini)>xs(mmer))){
 			horrible_counter=0;
 			mini=mmer;
@@ -434,11 +438,11 @@ extended_minimizer kmer_Set_Light::minimizer_and_more(kmer seq){
 uint32_t kmer_Set_Light::regular_minimizer(kmer seq){
 	uint32_t mini,mmer;
 	mmer=seq%minimizer_number_graph;
-	mini=min(mmer,(uint32_t)rcb(mmer,minimizer_size_graph));
+	mini=min(mmer,rcb(mmer,minimizer_size_graph));
 	for(uint i(1);i<=k-minimizer_size_graph;i++){
 		seq>>=2;
 		mmer=seq%minimizer_number_graph;
-		mmer=min(mmer,(uint32_t)rcb(mmer,minimizer_size_graph));
+		mmer=min(mmer,rcb(mmer,minimizer_size_graph));
 		if((xs(mini)>xs(mmer))){
 			mini=mmer;
 		}
@@ -452,11 +456,11 @@ uint32_t kmer_Set_Light::minimizer_extended(kmer seq){
 	kmer seq2(seq);
 	uint32_t mini,mmer,position_minimizer(0);
 	mini=seq%minimizer_number;
-	mini=min(mini,(uint32_t)rcb(mini,m1));
+	mini=min(mini,rcb(mini,m1));
 	for(uint i(0);i<k-m1;i++){
 		seq>>=2;
 		mmer=seq%minimizer_number;
-		mmer=min(mmer,(uint32_t)rcb(mmer,m1));
+		mmer=min(mmer,rcb(mmer,m1));
 		if((xs(mini)>xs(mmer))?mini:mmer){
 			mini=mmer;
 			position_minimizer=i;
@@ -468,7 +472,7 @@ uint32_t kmer_Set_Light::minimizer_extended(kmer seq){
 		mini=get_int_in_kmer(seq2,0,m1+position_minimizer+extension_minimizer);
 		mini<<=(2*(extension_minimizer-position_minimizer));
 	}
-	mini=min(mini,(uint32_t)rcb(mini,m1));
+	mini=min(mini,rcb(mini,m1));
 	return mini;
 }
 
@@ -482,13 +486,11 @@ void kmer_Set_Light::abundance_minimizer_construct(const string& input_file){
 		exit(1);
 	}
 	string ref,useless;
-	kmer minimizer;
 	while(not inUnitigs->eof()){
 		getline(*inUnitigs,useless);
 		getline(*inUnitigs,ref);
 		//FOREACH UNITIG
 		if(not ref.empty() and not useless.empty()){
-			uint last_position(0);
 			//FOREACH KMER
 			kmer seq(str2num(ref.substr(0,m1))),rcSeq(rcb(seq,m1)),canon(min_k(seq,rcSeq));
 			//~ abundance_minimizer[canon]++;
@@ -583,7 +585,7 @@ void kmer_Set_Light::create_super_buckets_extended(const string& input_file){
 					updateRCK(rcSeq,ref[i+k]);
 					canon=(min_k(seq, rcSeq));
 					//COMPUTE KMER MINIMIZER
-					auto nadine(minimizer_and_more(canon));
+					nadine = minimizer_and_more(canon);
 					uint new_fragile(nadine.fragile);
 					minimizer=nadine.mini;
 					precise_minimizer=nadine.extended_mini;
@@ -1232,7 +1234,7 @@ pair<uint32_t,uint32_t> kmer_Set_Light::query_sequence_bool(const string& query)
 	if(query.size()<k){
 		return make_pair(0,0);
 	}
-	kmer seq(str2num(query.substr(0,k))),rcSeq(rcb(seq,k)),canon(min_k(seq,rcSeq)),canonR,seqR,rcSeqR;
+	kmer seq(str2num(query.substr(0,k))),rcSeq(rcb(seq,k)),canon(min_k(seq,rcSeq));
 	uint i(0);
 	canon=(min_k(seq, rcSeq));
 	if(query_kmer_bool(canon)){++res;}else{++fail;}
@@ -1252,7 +1254,7 @@ vector<int64_t> kmer_Set_Light::query_sequence_hash(const string& query){
 	if(query.size()<k){
 		return res;
 	}
-	kmer seq(str2num(query.substr(0,k))),rcSeq(rcb(seq,k)),canon(min_k(seq,rcSeq)),canonR,seqR,rcSeqR;
+	kmer seq(str2num(query.substr(0,k))),rcSeq(rcb(seq,k)),canon(min_k(seq,rcSeq));
 	uint i(0);
 	canon=(min_k(seq, rcSeq));
 	res.push_back(query_kmer_hash(canon));
@@ -1281,13 +1283,12 @@ uint kmer_Set_Light::multiple_query_serial(const uint minimizer, const vector<km
 
 
 bool kmer_Set_Light::multiple_minimizer_query_bool(uint minimizer, kmer kastor,uint prefix_length,uint suffix_length){
-	uint res(0);
 	if(suffix_length>0){
 		uint32_t max_completion(1);
 		max_completion<<=(2*suffix_length);
 		minimizer<<=(2*suffix_length);
 		for(uint i(0);i<max_completion;++i){
-			uint32_t poential_min(min(minimizer+i,(uint32_t)rcb(minimizer+i,m1)));
+			uint32_t poential_min(min(minimizer+i,rcb(minimizer+i,m1)));
 			if(single_query(poential_min,kastor)){
 				return true;
 			}
@@ -1299,7 +1300,7 @@ bool kmer_Set_Light::multiple_minimizer_query_bool(uint minimizer, kmer kastor,u
 		max_completion<<=(2*(prefix_length));
 		mask<<=(2*(m1-prefix_length));
 		for(uint i(0);i<max_completion;++i){
-			uint32_t poential_min(min(minimizer+i*mask,(uint32_t)rcb(minimizer+i*mask,m1)));
+			uint32_t poential_min(min(minimizer+i*mask,rcb(minimizer+i*mask,m1)));
 			if(single_query(poential_min,kastor)){
 				return true;
 			}
@@ -1310,13 +1311,12 @@ bool kmer_Set_Light::multiple_minimizer_query_bool(uint minimizer, kmer kastor,u
 
 
 int64_t kmer_Set_Light::multiple_minimizer_query_hash(uint minimizer, kmer kastor,uint prefix_length,uint suffix_length){
-	uint res(0);
 	if(suffix_length>0){
 		uint32_t max_completion(1);
 		max_completion<<=(2*suffix_length);
 		minimizer<<=(2*suffix_length);
 		for(uint i(0);i<max_completion;++i){
-			uint32_t poential_min(min(minimizer+i,(uint32_t)rcb(minimizer+i,m1)));
+			uint32_t poential_min(min(minimizer+i,rcb(minimizer+i,m1)));
 			return query_get_hash(kastor,poential_min);
 		}
 	}
@@ -1326,7 +1326,7 @@ int64_t kmer_Set_Light::multiple_minimizer_query_hash(uint minimizer, kmer kasto
 		max_completion<<=(2*(prefix_length));
 		mask<<=(2*(m1-prefix_length));
 		for(uint i(0);i<max_completion;++i){
-			uint32_t poential_min(min(minimizer+i*mask,(uint32_t)rcb(minimizer+i*mask,m1)));
+			uint32_t poential_min(min(minimizer+i*mask,rcb(minimizer+i*mask,m1)));
 			return query_get_hash(kastor,poential_min);
 		}
 	}
@@ -1364,14 +1364,10 @@ uint kmer_Set_Light::multiple_query_optimized(uint32_t minimizer, const vector<k
 				res+=next-i+1;
 				i=next;
 			}else{
-				if(pos>=0){
-					++res;
-				}
+                ++res;
 			}
 		}else{
-			if(pos>=0){
-				++res;
-			}
+            ++res;
 		}
 	}
 	return res;
@@ -1400,9 +1396,7 @@ int32_t kmer_Set_Light::query_get_pos_unitig(const kmer canon,uint minimizer){
 			if(canon==canonR){
 				return pos;
 			}else{
-				uint64_t j;
-				bool found(false);
-				for(j=(pos);j<pos+positions_to_check.size();++j){
+				for(uint64_t j=(pos);j<pos+positions_to_check.size();++j){
 					seqR=update_kmer(j+k,minimizer,seqR);//can be avoided
 					rcSeqR=(rcb(seqR,k));
 					canonR=(min_k(seqR, rcSeqR));
@@ -1438,9 +1432,7 @@ int64_t kmer_Set_Light::query_get_hash(const kmer canon,uint minimizer){
 			if(canon==canonR){
 				return hash+all_mphf[minimizer/number_bucket_per_mphf].mphf_size;
 			}else{
-				uint64_t j;
-				bool found(false);
-				for(j=(pos);j<pos+positions_to_check.size();++j){
+				for(uint64_t j=(pos);j<pos+positions_to_check.size();++j){
 					seqR=update_kmer(j+k,minimizer,seqR);//can be avoided
 					rcSeqR=(rcb(seqR,k));
 					canonR=(min_k(seqR, rcSeqR));
@@ -1456,14 +1448,13 @@ int64_t kmer_Set_Light::query_get_hash(const kmer canon,uint minimizer){
 
 
 
-void kmer_Set_Light::file_query(const string& query_file,bool optimized){
+void kmer_Set_Light::file_query(const string& query_file){
 	high_resolution_clock::time_point t1 = high_resolution_clock::now();
 	auto in=new zstr::ifstream(query_file);
 	uint64_t TP(0),FP(0);
 	#pragma omp parallel num_threads(coreNumber)
 	{
 		vector<kmer> kmerV;
-		uint32_t minimizer;
 		while(not in->eof() and in->good()){
 			string query;
 			#pragma omp critical(dataupdate)

--- a/blight.h
+++ b/blight.h
@@ -12,6 +12,7 @@
 #include <stdint.h>
 #include <unordered_map>
 #include <pthread.h>
+#include "common.h"
 #include "bbhash.h"
 
 
@@ -38,20 +39,20 @@ typedef boomphf::mphf<  kmer, hasher_t  > MPHF;
 
 
 struct bucket_minimizer{
-	//~ uint32_t abundance_minimizer;
-	uint32_t nuc_minimizer;
 	uint64_t current_pos;
 	uint64_t start;
+	//~ uint32_t abundance_minimizer;
+	uint32_t nuc_minimizer;
 };
 
 
 
 struct info_mphf{
-	bool empty;
 	uint64_t mphf_size;
 	uint64_t start;
-	uint8_t bit_to_encode;
 	MPHF* kmer_MPHF;
+	uint8_t bit_to_encode;
+	bool empty;
 };
 
 
@@ -68,7 +69,9 @@ struct extended_minimizer{
 // Represents the cardinality of a pow2 sized set. Allows div/mod arithmetic operations on indexes.
 template<typename T>
 struct Pow2 {
-	Pow2(uint_fast8_t bits) : _bits(bits) {}
+	Pow2(uint_fast8_t bits) : _bits(bits) {
+		assume(bits <= CHAR_BIT*sizeof(T), "Pow2(%u > %u)", unsigned(bits), unsigned(CHAR_BIT*sizeof(T)));
+	}
 
 	uint_fast8_t bits() const { return _bits; }
 	T size() const { return T(1) << _bits; }
@@ -189,7 +192,7 @@ public:
 	int32_t query_get_pos_unitig(const kmer canon,uint minimizer);
 	uint32_t get_anchors(const string& query,uint& minimizer, vector<kmer>& kmerV,uint pos);
 	uint multiple_query_serial(const uint minimizerV, const vector<kmer>& kmerV);
-	void file_query(const string& query_file,bool bi);
+	void file_query(const string& query_file);
 	uint32_t bool_to_int(uint n_bits_to_encode,uint64_t pos,uint64_t start);
 	uint multiple_query_optimized(uint minimizerV, const vector<kmer>& kmerV);
 	void int_to_bool(uint n_bits_to_encode,uint64_t X, uint64_t pos,uint64_t start);

--- a/common.h
+++ b/common.h
@@ -1,0 +1,79 @@
+#ifndef COMMON_HPP
+#define COMMON_HPP
+
+#include <cstdio>
+#include <cstdarg>
+#include <exception>
+
+#define noinline_fun __attribute__((noinline))
+#define forceinline_fun inline __attribute__((always_inline))
+#define flatten_fun __attribute__((flatten))
+#define pure_fun __attribute__((pure))
+#define hot_fun __attribute__((hot))
+#define cold_fun __attribute__((cold))
+#define restrict __restrict__
+#define likely(expr) __builtin_expect(!!(expr), 1)
+#define unlikely(expr) __builtin_expect(!!(expr), 0)
+#define prefetchr(addr) __builtin_prefetch((addr), 0)
+#define prefetchw(addr) __builtin_prefetch((addr), 1)
+
+#ifndef __has_feature
+#    define __has_feature(x) (0)
+#endif
+
+#ifdef __has_cpp_attribute
+#    if __has_cpp_attribute(noreturn)
+#        define noreturn_attr [[noreturn]]
+#    endif
+#    if __has_cpp_attribute(nodiscard)
+#        define nodiscard_attr [[nodiscard]]
+#    elif __has_cpp_attribute(gnu::warn_unused_result)
+#        define nodiscard_attr [[gnu::warn_unused_result]]
+#    endif
+#endif
+
+#ifndef noreturn_attr
+#    define noreturn_attr __attribute__((noreturn))
+#endif
+
+#ifndef nodiscard_attr
+#    define nodiscard_attr __attribute__((warn_unused_result))
+#endif
+
+#ifdef assert
+#    undef assert
+#endif
+
+#ifdef NDEBUG
+#    define DEBUG 0
+#    define assert(...) (static_cast<void>(0))
+#    define assume(expr, ...) (likely((expr)) ? static_cast<void>(0) : __builtin_unreachable())
+#else
+#    define DEBUG 1
+
+
+/** Handler for assertion/assumption fails
+ * Do not throw exception on purpose (directly terminate)
+ */
+noreturn_attr noinline_fun inline void
+abort_message(const char msg[]...)
+{
+    va_list args;
+    va_start(args, msg);
+    std::vfprintf(stderr, msg, args);
+    va_end(args);
+    std::fflush(stderr);
+    std::abort();
+}
+
+
+#    define sourceloc_fail(what, msg, ...) abort_message("%s:%u:%s\n\t" what " failed: " msg "\n", __FILE__, __LINE__, __PRETTY_FUNCTION__, ##__VA_ARGS__))
+//#    define sourceloc_fail1(what) abort_message("%s:%s:%u: " #what " failed.\n", __FILE__, __PRETTY_FUNCTION__, __LINE__))
+//#define __sourceloc_fail_nargs(
+
+#    define assert(expr, ...) (likely((expr)) ? static_cast<void>(0) : sourceloc_fail("Assertion '" #expr "'", ##__VA_ARGS__)
+#    define assume(expr, ...) (likely((expr)) ? static_cast<void>(0) : sourceloc_fail("Assumption '" #expr "'", ##__VA_ARGS__)
+
+#endif
+
+#endif // COMMON_HPP

--- a/makefile
+++ b/makefile
@@ -1,21 +1,35 @@
 CC=g++
-CFLAGS=   -Ofast -std=c++11 -flto   -pipe -funit-at-a-time  -Wfatal-errors -lz -fopenmp
-LDFLAGS= -lpthread -lz -flto -fopenmp
 
+DEBUG ?= 0
+ifeq ($(DEBUG), 1)
+	CFLAGS+=-Og -DDEBUG
+	WARNS= -Wall -Wextra -Wno-format -Werror=float-equal -Wuseless-cast -Wlogical-op -Wcast-align -Wtrampolines -Werror=enum-compare -Wstrict-aliasing=2 -Werror=parentheses -Wnull-dereference -Werror=restrict -Werror=logical-op -Wsync-nand -Werror=main -Wshift-overflow=2 -Werror=pointer-sign -Wcast-qual -Werror=array-bounds -Werror=char-subscripts -Wshadow -Werror=ignored-qualifiers -Werror=sequence-point -Werror=address -Wduplicated-branches -Wsign-compare -Wodr -Wno-unknown-pragmas -Wnarrowing -Wsuggest-final-methods  -Wformat-signedness -Wrestrict -Werror=aggressive-loop-optimizations -Werror=missing-braces -Werror=uninitialized -Wframe-larger-than=32768 -Werror=nonnull -Wno-unused-function -Werror=init-self -Werror=empty-body -Wdouble-promotion -Wfatal-errors -Werror=old-style-declaration -Wduplicated-cond -Werror=write-strings -Werror=return-type -Werror=volatile-register-var -Wsuggest-final-types -Werror=missing-parameter-type -Werror=implicit-int
+	DEBUG_SYMS=1
+else
+	CFLAGS+=-DNDEBUG -O3 -flto -march=native -mtune=native
+	WARNS=-Wfatal-errors
+endif
+
+DEBUG_SYMS ?= 1
+ifeq ($(DEBUG_SYMS), 1)
+	CFLAGS+=-g
+endif
+
+CFLAGS+=-std=c++11 -pipe -lz -fopenmp ${WARNS}
 
 EXEC=bench_blight Colored_De_Bruijn_graph_snippet Abundance_De_Bruijn_graph_snippet
 
 
 all: $(EXEC)
 
-Colored_De_Bruijn_graph_snippet: Colored_De_Bruijn_graph_snippet.o blight.o mmh.o
-	$(CC) -o $@ $^ $(LDFLAGS)
+Colored_De_Bruijn_graph_snippet: Colored_De_Bruijn_graph_snippet.o blight.o
+	$(CC) -o $@ $^ $(CFLAGS)
 
-Abundance_De_Bruijn_graph_snippet: Abundance_De_Bruijn_graph_snippet.o blight.o mmh.o
-	$(CC) -o $@ $^ $(LDFLAGS)
+Abundance_De_Bruijn_graph_snippet: Abundance_De_Bruijn_graph_snippet.o blight.o
+	$(CC) -o $@ $^ $(CFLAGS)
 
-bench_blight: bench_blight.o blight.o mmh.o
-	$(CC) -o $@ $^ $(LDFLAGS)
+bench_blight: bench_blight.o blight.o
+	$(CC) -o $@ $^ $(CFLAGS)
 
 bench_blight.o: bench_blight.cpp blight.h
 	$(CC) -o $@ -c $< $(CFLAGS)
@@ -24,9 +38,6 @@ Colored_De_Bruijn_graph_snippet.o: Colored_De_Bruijn_graph_snippet.cpp blight.h
 	$(CC) -o $@ -c $< $(CFLAGS)
 
 Abundance_De_Bruijn_graph_snippet.o: Abundance_De_Bruijn_graph_snippet.cpp blight.h
-	$(CC) -o $@ -c $< $(CFLAGS)
-
-mmh.o: MurmurHash3.cpp MurmurHash3.h
 	$(CC) -o $@ -c $< $(CFLAGS)
 
 blight.o: blight.cpp

--- a/zstr.hpp
+++ b/zstr.hpp
@@ -222,7 +222,7 @@ private:
     static const std::size_t default_buff_size = (std::size_t)1 << 20;
 }; // class istreambuf
 
-class ostreambuf
+class ostreambuf final
     : public std::streambuf
 {
 public:
@@ -318,7 +318,7 @@ private:
     static const std::size_t default_buff_size = (std::size_t)1 << 20;
 }; // class ostreambuf
 
-class istream
+class istream final
     : public std::istream
 {
 public:
@@ -383,7 +383,7 @@ public:
     {
         exceptions(std::ios_base::badbit);
     }
-    virtual ~ifstream()
+    virtual ~ifstream() final
     {
         if (rdbuf()) delete rdbuf();
     }


### PR DESCRIPTION
BBhash now use a single bit vector instead of one for each level (hard coded to 25 levels, now 16).
Temporaries structures are no longer class members.
A new "fast mode" algorithm is implemented, it consumes 1bit per input key during construction.

On c.el. the peak RSS went from 460MB to 330MB (but it varies between runs because of multi-threading)
Also a small time improvement: 116s -> 95s CPU time for the whole `bench_blight` sketch.